### PR TITLE
Add IFactionMembers implementations for Ecliptic, Varuun, and Spacer factions

### DIFF
--- a/Retrograde/FactionMembers/EclipticFactionCrew.cs
+++ b/Retrograde/FactionMembers/EclipticFactionCrew.cs
@@ -1,0 +1,277 @@
+﻿using DynamicData;
+using FrankyCLI.questgen_tools.Interfaces;
+using FrankyCLI.Retrograde.FactionMembers;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Starfield;
+using Noggog;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using static Mutagen.Bethesda.FormKeys.Starfield.Starfield;
+
+namespace FrankyCLI.questgen_tools
+{
+    public class EclipticFactionCrew : IFactionMembers
+    {
+        List<Npc> LowRank { get; set; }
+        List<Npc> HighRank { get; set; }
+        List<Npc> Bosses { get; set; }
+        public EclipticFactionCrew()
+        {
+            string Faction = "Ecliptic";
+            Random random = RandomUtils.random;
+            string Crewname = Faction;
+
+            int lowrank_crewcount = 10;
+            int highrank_crewcount = 5;
+            int boss_crewcount = 1;
+
+            LowRank = new List<Npc>();
+            HighRank = new List<Npc>();
+            Bosses = new List<Npc>();
+
+            //Low Rank
+            for (int i = 0; i < lowrank_crewcount; i++)
+            {
+                bool isfemale = false;
+                if (random.Next(100) > 75)
+                {
+                    isfemale = true;
+                }
+                var NPC = gen_quest_main.myMod.Npcs[new FormKey(gen_quest_main.myMod.ModKey, NPCTools.GetTemplateNPC(isfemale))].DeepCopy();
+                Npc npc = NPCTools.CloneNPC(gen_quest_main.myMod, NPC);
+
+                //Ranked Info
+                var outfit = GetLowRank_Outfit();
+                npc.Name = "Ecliptic" + " " + GetLowRank_Name();
+                var gear = GetLowRank_Gear();
+                var lev = new PcLevelMult();
+                lev.LevelMult = 0.5f + ((float)random.NextDouble()/2);
+                npc.Level = lev;
+
+                CreateNPC(Faction, random, isfemale, npc, outfit, gear);
+
+                LowRank.Add(npc);
+            }
+
+            //High Rank
+            for (int i = 0; i < highrank_crewcount; i++)
+            {
+                bool isfemale = false;
+                if (random.Next(100) > 75)
+                {
+                    isfemale = true;
+                }
+                var NPC = gen_quest_main.myMod.Npcs[new FormKey(gen_quest_main.myMod.ModKey, NPCTools.GetTemplateNPC(isfemale))].DeepCopy();
+                Npc npc = NPCTools.CloneNPC(gen_quest_main.myMod, NPC);
+
+                //Ranked Info
+                var outfit = GetHighRank_Outfit();
+                npc.Name = "Ecliptic" + " " + GetHighRank_Name();
+                var gear = GetHighRank_Gear();
+                var lev = new PcLevelMult();
+                lev.LevelMult = 0.75f + (float)random.NextDouble();
+                npc.Level = lev;
+
+                CreateNPC(Faction, random, isfemale, npc, outfit, gear);
+                HighRank.Add(npc);
+
+            }
+
+            for (int i = 0; i < boss_crewcount; i++)
+            {
+                bool isfemale = false;
+                if (random.Next(100) > 50)
+                {
+                    isfemale = true;
+                }
+                var NPC = gen_quest_main.myMod.Npcs[new FormKey(gen_quest_main.myMod.ModKey, NPCTools.GetTemplateNPC(isfemale))].DeepCopy();
+                Npc npc = NPCTools.CloneNPC(gen_quest_main.myMod, NPC);
+
+                //Ranked Info
+                var outfit = GetBoss_Outfit();
+                npc.Name = "Ecliptic" + " " + GetBoss_Name();
+                var gear = GetBoss_Gear();
+                var lev = new PcLevelMult();
+                lev.LevelMult = 1 + (float)random.NextDouble();
+                npc.Level = lev;
+
+                CreateNPC(Faction, random, isfemale, npc, outfit, gear);
+                Bosses.Add(npc);
+            }
+        }
+
+        private void CreateNPC(string Faction, Random random, bool isfemale, Npc npc, IFormLinkNullable<IOutfitGetter> outfit, IFormLinkNullable<ILeveledItemGetter> gear)
+        {
+            //Generate Member
+            string Gender = "Male";
+            if (isfemale) Gender = "Female";
+            npc.EditorID = "npc_" + (npc.Name.ToString().ToLower()).Replace(" ", "");
+            npc.Voice = NPCTools.GetVoice(Faction, isfemale);
+            npc.Factions.Clear();
+            npc.Factions.Add(NPCTools.GetFaction(Faction));
+            npc.Weight = new NpcWeight()
+            {
+                Fat = (float)random.NextDouble() /2,
+                Muscular = (float)random.NextDouble(),
+                Thin = (float)random.NextDouble()/2
+            };
+            npc.SpaceOutfit = outfit;
+            npc.EyeColor = NPCTools.GetEyeColour();
+            npc.HairColor = NPCTools.GetHairColour();
+            npc.SkinToneIndex = (byte)random.Next(8);
+            npc.HeadParts.Add(NPCTools.GetHaircut(isfemale));
+            npc.Items = new ExtendedList<ContainerEntry>
+                {
+                    new ContainerEntry() { Item = new ContainerItem() { Item = gear, Count = 1 } },
+                };
+            gen_quest_main.myMod.Npcs.Add(npc);
+        }
+
+        public IFormLinkNullable<IOutfitGetter> GetLowRank_Outfit()
+        {
+            Random random = RandomUtils.random;
+            List<uint> Outfits = new List<uint>
+            {
+                0x00042D85,// Outfit_Worker [OTFT:00042D85]
+                0x0029B9D4,// LL_Clothes_Settler_Any [LVLI:0029B9D4]
+                0x0003A0CF,// LL_Clothes_Worker_Any [LVLI:0003A0CF]
+            };
+            IFormLinkNullable<IOutfitGetter> outfit = new FormKey(gen_quest_main.StarfieldModKey, Outfits[random.Next(Outfits.Count)]).ToNullableLink<IOutfitGetter>();
+            return outfit;
+        }
+
+        public IFormLinkNullable<IOutfitGetter> GetHighRank_Outfit()
+        {
+            Random random = RandomUtils.random;
+            List<uint> Outfits = new List<uint>
+            {
+                0x0027027D,//Outfit_Spacesuit_Ecliptic [OTFT:0027027D]
+            };
+            IFormLinkNullable<IOutfitGetter> outfit = new FormKey(gen_quest_main.StarfieldModKey, Outfits[random.Next(Outfits.Count)]).ToNullableLink<IOutfitGetter>();
+            return outfit;
+        }
+
+        public IFormLinkNullable<IOutfitGetter> GetBoss_Outfit()
+        {
+            Random random = RandomUtils.random;
+            List<uint> Outfits = new List<uint>
+            {
+                0x0027027D,//Outfit_Spacesuit_Ecliptic [OTFT:0027027D]
+            };
+            IFormLinkNullable<IOutfitGetter> outfit = new FormKey(gen_quest_main.StarfieldModKey, Outfits[random.Next(Outfits.Count)]).ToNullableLink<IOutfitGetter>();
+            return outfit;
+        }
+
+        public string GetLowRank_Name()
+        {
+            Random r = RandomUtils.random;
+            var roles = new List<string>
+            {
+                "Recruit","Field Recruit","New Recruit","Fresh Recruit",
+                "Trooper","Patrol Trooper","Garrison Trooper","Perimeter Trooper",
+                "Operative","Field Operative","Scout Operative","Recon Operative",
+                "Grunt","Cargo Grunt","Station Grunt","Outpost Grunt",
+                "Sentry","Gate Sentry","Dock Sentry","Tower Sentry",
+                "Technician","Field Technician","Comms Technician","Systems Technician",
+                "Scout","Forward Scout","Perimeter Scout","Patrol Scout",
+                "Guard","Post Guard","Checkpoint Guard","Facility Guard"
+            };
+            return roles[r.Next(roles.Count)];
+        }
+
+        public string GetHighRank_Name()
+        {
+            Random r = RandomUtils.random;
+            var roles = new List<string>
+            {
+                "Squad Lead","Fire Team Lead","Patrol Lead","Assault Lead",
+                "Sergeant","Field Sergeant","Combat Sergeant","Operations Sergeant",
+                "Specialist","Weapons Specialist","Demolitions Specialist","Comms Specialist",
+                "Veteran","Combat Veteran","Field Veteran","Senior Veteran",
+                "Officer","Field Officer","Tactical Officer","Watch Officer",
+                "Lieutenant","Junior Lieutenant","Acting Lieutenant"
+            };
+            return roles[r.Next(roles.Count)];
+        }
+
+        public string GetBoss_Name()
+        {
+            Random r = RandomUtils.random;
+            var roles = new List<string>
+            {
+                "Commander","Field Commander","Station Commander","Operations Commander",
+                "Captain","Strike Captain","Garrison Captain","Assault Captain",
+                "Colonel","Field Colonel","Senior Colonel",
+                "Director","Operations Director","Field Director","Tactical Director",
+                "Overseer","Station Overseer","Sector Overseer",
+                "Warden","Station Warden","Garrison Warden",
+                "General","Brigadier","Marshal"
+            };
+            return roles[r.Next(roles.Count)];
+        }
+
+        public IFormLinkNullable<ILeveledItemGetter> GetLowRank_Gear()
+        {
+            Random random = RandomUtils.random;
+            List<uint> gearlist = new List<uint>()
+                {
+                    0x003D60AF,//LLI_Ecliptic_AssaultDefaultRole [LVLI:003D60AF]
+                    0x003D60B0,//LLI_Ecliptic_Charger [LVLI:003D60B0]
+                    0x003D60B1,//LLI_Ecliptic_Heavy [LVLI:003D60B1]
+                    0x003D60B4,//LLI_Ecliptic_Sniper [LVLI:003D60B4]
+                    0x003D60B3,//LLI_Ecliptic_Recruit [LVLI:003D60B3]
+                    0x003D60B5,//LLI_Ecliptic_Support [LVLI:003D60B5]
+                };
+            IFormLinkNullable<ILeveledItemGetter> gear = new FormKey(gen_quest_main.StarfieldModKey, gearlist[random.Next(gearlist.Count)]).ToNullableLink<ILeveledItemGetter>();
+            return gear;
+        }
+
+        public IFormLinkNullable<ILeveledItemGetter> GetHighRank_Gear()
+        {
+            Random random = RandomUtils.random;
+            List<uint> gearlist = new List<uint>()
+                {
+                    0x003D60B2,//LLI_Ecliptic_Officer [LVLI:003D60B2]
+                    0x003D60AF,//LLI_Ecliptic_AssaultDefaultRole [LVLI:003D60AF]
+                    0x003D60B1,//LLI_Ecliptic_Heavy [LVLI:003D60B1]
+                    0x003D60B4,//LLI_Ecliptic_Sniper [LVLI:003D60B4]
+                };
+            IFormLinkNullable<ILeveledItemGetter> gear = new FormKey(gen_quest_main.StarfieldModKey, gearlist[random.Next(gearlist.Count)]).ToNullableLink<ILeveledItemGetter>();
+            return gear;
+        }
+
+        public IFormLinkNullable<ILeveledItemGetter> GetBoss_Gear()
+        {
+            Random random = RandomUtils.random;
+            List<uint> gearlist = new List<uint>()
+                {
+                    0x003D60B2,//LLI_Ecliptic_Officer [LVLI:003D60B2]
+                    0x003D60B1,//LLI_Ecliptic_Heavy [LVLI:003D60B1]
+                };
+            IFormLinkNullable<ILeveledItemGetter> gear = new FormKey(gen_quest_main.StarfieldModKey, gearlist[random.Next(gearlist.Count)]).ToNullableLink<ILeveledItemGetter>();
+            return gear;
+        }
+
+        public Npc GetCrewMember(string Room)
+        {
+            Npc selected = null;
+            int roll = RandomUtils.random.Next(100);
+            if (roll > 60)
+            {
+                selected = HighRank[RandomUtils.random.Next(HighRank.Count)];
+            }
+            else
+            {
+                selected = LowRank[RandomUtils.random.Next(LowRank.Count)];
+            }
+            return selected;
+        }
+
+        public Npc GetBoss(string Room)
+        {
+            return Bosses[RandomUtils.random.Next(Bosses.Count)];
+        }
+    }
+}

--- a/Retrograde/FactionMembers/SpacerFactionCrew.cs
+++ b/Retrograde/FactionMembers/SpacerFactionCrew.cs
@@ -1,0 +1,276 @@
+﻿using DynamicData;
+using FrankyCLI.questgen_tools.Interfaces;
+using FrankyCLI.Retrograde.FactionMembers;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Starfield;
+using Noggog;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using static Mutagen.Bethesda.FormKeys.Starfield.Starfield;
+
+namespace FrankyCLI.questgen_tools
+{
+    public class SpacerFactionCrew : IFactionMembers
+    {
+        List<Npc> LowRank { get; set; }
+        List<Npc> HighRank { get; set; }
+        List<Npc> Bosses { get; set; }
+        public SpacerFactionCrew()
+        {
+            string Faction = "Spacer";
+            Random random = RandomUtils.random;
+            string Crewname = Faction;
+
+            int lowrank_crewcount = 10;
+            int highrank_crewcount = 5;
+            int boss_crewcount = 1;
+
+            LowRank = new List<Npc>();
+            HighRank = new List<Npc>();
+            Bosses = new List<Npc>();
+
+            //Low Rank
+            for (int i = 0; i < lowrank_crewcount; i++)
+            {
+                bool isfemale = false;
+                if (random.Next(100) > 75)
+                {
+                    isfemale = true;
+                }
+                var NPC = gen_quest_main.myMod.Npcs[new FormKey(gen_quest_main.myMod.ModKey, NPCTools.GetTemplateNPC(isfemale))].DeepCopy();
+                Npc npc = NPCTools.CloneNPC(gen_quest_main.myMod, NPC);
+
+                //Ranked Info
+                var outfit = GetLowRank_Outfit();
+                npc.Name = "Spacer" + " " + GetLowRank_Name();
+                var gear = GetLowRank_Gear();
+                var lev = new PcLevelMult();
+                lev.LevelMult = 0.5f + ((float)random.NextDouble()/2);
+                npc.Level = lev;
+
+                CreateNPC(Faction, random, isfemale, npc, outfit, gear);
+
+                LowRank.Add(npc);
+            }
+
+            //High Rank
+            for (int i = 0; i < highrank_crewcount; i++)
+            {
+                bool isfemale = false;
+                if (random.Next(100) > 75)
+                {
+                    isfemale = true;
+                }
+                var NPC = gen_quest_main.myMod.Npcs[new FormKey(gen_quest_main.myMod.ModKey, NPCTools.GetTemplateNPC(isfemale))].DeepCopy();
+                Npc npc = NPCTools.CloneNPC(gen_quest_main.myMod, NPC);
+
+                //Ranked Info
+                var outfit = GetHighRank_Outfit();
+                npc.Name = "Spacer" + " " + GetHighRank_Name();
+                var gear = GetHighRank_Gear();
+                var lev = new PcLevelMult();
+                lev.LevelMult = 0.75f + (float)random.NextDouble();
+                npc.Level = lev;
+
+                CreateNPC(Faction, random, isfemale, npc, outfit, gear);
+                HighRank.Add(npc);
+
+            }
+
+            for (int i = 0; i < boss_crewcount; i++)
+            {
+                bool isfemale = false;
+                if (random.Next(100) > 50)
+                {
+                    isfemale = true;
+                }
+                var NPC = gen_quest_main.myMod.Npcs[new FormKey(gen_quest_main.myMod.ModKey, NPCTools.GetTemplateNPC(isfemale))].DeepCopy();
+                Npc npc = NPCTools.CloneNPC(gen_quest_main.myMod, NPC);
+
+                //Ranked Info
+                var outfit = GetBoss_Outfit();
+                npc.Name = "Spacer" + " " + GetBoss_Name();
+                var gear = GetBoss_Gear();
+                var lev = new PcLevelMult();
+                lev.LevelMult = 1 + (float)random.NextDouble();
+                npc.Level = lev;
+
+                CreateNPC(Faction, random, isfemale, npc, outfit, gear);
+                Bosses.Add(npc);
+            }
+        }
+
+        private void CreateNPC(string Faction, Random random, bool isfemale, Npc npc, IFormLinkNullable<IOutfitGetter> outfit, IFormLinkNullable<ILeveledItemGetter> gear)
+        {
+            //Generate Member
+            string Gender = "Male";
+            if (isfemale) Gender = "Female";
+            npc.EditorID = "npc_" + (npc.Name.ToString().ToLower()).Replace(" ", "");
+            npc.Voice = NPCTools.GetVoice(Faction, isfemale);
+            npc.Factions.Clear();
+            npc.Factions.Add(NPCTools.GetFaction(Faction));
+            npc.Weight = new NpcWeight()
+            {
+                Fat = (float)random.NextDouble() /2,
+                Muscular = (float)random.NextDouble(),
+                Thin = (float)random.NextDouble()/2
+            };
+            npc.SpaceOutfit = outfit;
+            npc.EyeColor = NPCTools.GetEyeColour();
+            npc.HairColor = NPCTools.GetHairColour();
+            npc.SkinToneIndex = (byte)random.Next(8);
+            npc.HeadParts.Add(NPCTools.GetHaircut(isfemale));
+            npc.Items = new ExtendedList<ContainerEntry>
+                {
+                    new ContainerEntry() { Item = new ContainerItem() { Item = gear, Count = 1 } },
+                };
+            gen_quest_main.myMod.Npcs.Add(npc);
+        }
+
+        public IFormLinkNullable<IOutfitGetter> GetLowRank_Outfit()
+        {
+            Random random = RandomUtils.random;
+            List<uint> Outfits = new List<uint>
+            {
+                0x00042D85,// Outfit_Worker [OTFT:00042D85]
+                0x0029B9D4,// LL_Clothes_Settler_Any [LVLI:0029B9D4]
+                0x0003A0CF,// LL_Clothes_Worker_Any [LVLI:0003A0CF]
+            };
+            IFormLinkNullable<IOutfitGetter> outfit = new FormKey(gen_quest_main.StarfieldModKey, Outfits[random.Next(Outfits.Count)]).ToNullableLink<IOutfitGetter>();
+            return outfit;
+        }
+
+        public IFormLinkNullable<IOutfitGetter> GetHighRank_Outfit()
+        {
+            Random random = RandomUtils.random;
+            List<uint> Outfits = new List<uint>
+            {
+                0x0015E246,//Outfit_Spacesuit_Spacer_Any [OTFT:0015E246]
+            };
+            IFormLinkNullable<IOutfitGetter> outfit = new FormKey(gen_quest_main.StarfieldModKey, Outfits[random.Next(Outfits.Count)]).ToNullableLink<IOutfitGetter>();
+            return outfit;
+        }
+
+        public IFormLinkNullable<IOutfitGetter> GetBoss_Outfit()
+        {
+            Random random = RandomUtils.random;
+            List<uint> Outfits = new List<uint>
+            {
+                0x0015E246,//Outfit_Spacesuit_Spacer_Any [OTFT:0015E246]
+            };
+            IFormLinkNullable<IOutfitGetter> outfit = new FormKey(gen_quest_main.StarfieldModKey, Outfits[random.Next(Outfits.Count)]).ToNullableLink<IOutfitGetter>();
+            return outfit;
+        }
+
+        public string GetLowRank_Name()
+        {
+            Random r = RandomUtils.random;
+            var roles = new List<string>
+            {
+                "Scav","Hull Scav","Junk Scav","Wire Scav",
+                "Punk","Dock Punk","Station Punk","Cargo Punk",
+                "Rat","Tunnel Rat","Dock Rat","Vent Rat",
+                "Drifter","Armed Drifter","Station Drifter","Void Drifter",
+                "Thug","Alley Thug","Dock Thug","Cargo Thug",
+                "Scrapper","Hull Scrapper","Junk Scrapper","Wire Scrapper",
+                "Looter","Cargo Looter","Wreck Looter","Station Looter",
+                "Goon","Dock Goon","Gate Goon","Cargo Goon"
+            };
+            return roles[r.Next(roles.Count)];
+        }
+
+        public string GetHighRank_Name()
+        {
+            Random r = RandomUtils.random;
+            var roles = new List<string>
+            {
+                "Gang Lead","Dock Lead","Crew Lead","Raid Lead",
+                "Enforcer","Senior Enforcer","Head Enforcer","Station Enforcer",
+                "Bruiser","Head Bruiser","Dock Bruiser","Senior Bruiser",
+                "Veteran","Combat Veteran","Raid Veteran","Station Veteran",
+                "Raider","Senior Raider","Lead Raider","Void Raider",
+                "Lieutenant","Gang Lieutenant","Station Lieutenant"
+            };
+            return roles[r.Next(roles.Count)];
+        }
+
+        public string GetBoss_Name()
+        {
+            Random r = RandomUtils.random;
+            var roles = new List<string>
+            {
+                "Gang Boss","Dock Boss","Station Boss","Crew Boss",
+                "Warlord","Void Warlord","Station Warlord","Raid Warlord",
+                "Kingpin","Station Kingpin","Sector Kingpin",
+                "Overlord","Gang Overlord","Station Overlord",
+                "Captain","Raid Captain","Crew Captain","Void Captain",
+                "Chief","War Chief","Gang Chief","Station Chief",
+                "Commander","Raid Commander","Gang Commander"
+            };
+            return roles[r.Next(roles.Count)];
+        }
+
+        public IFormLinkNullable<ILeveledItemGetter> GetLowRank_Gear()
+        {
+            Random random = RandomUtils.random;
+            List<uint> gearlist = new List<uint>()
+                {
+                    0x003D0946,//LLI_Spacer_AssaultDefaultRole [LVLI:003D0946]
+                    0x003D0947,//LLI_Spacer_Charger [LVLI:003D0947]
+                    0x003D0948,//LLI_Spacer_Heavy [LVLI:003D0948]
+                    0x003D094B,//LLI_Spacer_Sniper [LVLI:003D094B]
+                    0x003D094A,//LLI_Spacer_Recruit [LVLI:003D094A]
+                };
+            IFormLinkNullable<ILeveledItemGetter> gear = new FormKey(gen_quest_main.StarfieldModKey, gearlist[random.Next(gearlist.Count)]).ToNullableLink<ILeveledItemGetter>();
+            return gear;
+        }
+
+        public IFormLinkNullable<ILeveledItemGetter> GetHighRank_Gear()
+        {
+            Random random = RandomUtils.random;
+            List<uint> gearlist = new List<uint>()
+                {
+                    0x003D0949,//LLI_Spacer_Officer [LVLI:003D0949]
+                    0x003D0946,//LLI_Spacer_AssaultDefaultRole [LVLI:003D0946]
+                    0x003D0948,//LLI_Spacer_Heavy [LVLI:003D0948]
+                    0x003D094B,//LLI_Spacer_Sniper [LVLI:003D094B]
+                };
+            IFormLinkNullable<ILeveledItemGetter> gear = new FormKey(gen_quest_main.StarfieldModKey, gearlist[random.Next(gearlist.Count)]).ToNullableLink<ILeveledItemGetter>();
+            return gear;
+        }
+
+        public IFormLinkNullable<ILeveledItemGetter> GetBoss_Gear()
+        {
+            Random random = RandomUtils.random;
+            List<uint> gearlist = new List<uint>()
+                {
+                    0x003D0949,//LLI_Spacer_Officer [LVLI:003D0949]
+                    0x003D0948,//LLI_Spacer_Heavy [LVLI:003D0948]
+                };
+            IFormLinkNullable<ILeveledItemGetter> gear = new FormKey(gen_quest_main.StarfieldModKey, gearlist[random.Next(gearlist.Count)]).ToNullableLink<ILeveledItemGetter>();
+            return gear;
+        }
+
+        public Npc GetCrewMember(string Room)
+        {
+            Npc selected = null;
+            int roll = RandomUtils.random.Next(100);
+            if (roll > 60)
+            {
+                selected = HighRank[RandomUtils.random.Next(HighRank.Count)];
+            }
+            else
+            {
+                selected = LowRank[RandomUtils.random.Next(LowRank.Count)];
+            }
+            return selected;
+        }
+
+        public Npc GetBoss(string Room)
+        {
+            return Bosses[RandomUtils.random.Next(Bosses.Count)];
+        }
+    }
+}

--- a/Retrograde/FactionMembers/VaruunFactionCrew.cs
+++ b/Retrograde/FactionMembers/VaruunFactionCrew.cs
@@ -1,0 +1,276 @@
+﻿using DynamicData;
+using FrankyCLI.questgen_tools.Interfaces;
+using FrankyCLI.Retrograde.FactionMembers;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Starfield;
+using Noggog;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using static Mutagen.Bethesda.FormKeys.Starfield.Starfield;
+
+namespace FrankyCLI.questgen_tools
+{
+    public class VaruunFactionCrew : IFactionMembers
+    {
+        List<Npc> LowRank { get; set; }
+        List<Npc> HighRank { get; set; }
+        List<Npc> Bosses { get; set; }
+        public VaruunFactionCrew()
+        {
+            string Faction = "Varuun";
+            Random random = RandomUtils.random;
+            string Crewname = Faction;
+
+            int lowrank_crewcount = 10;
+            int highrank_crewcount = 5;
+            int boss_crewcount = 1;
+
+            LowRank = new List<Npc>();
+            HighRank = new List<Npc>();
+            Bosses = new List<Npc>();
+
+            //Low Rank
+            for (int i = 0; i < lowrank_crewcount; i++)
+            {
+                bool isfemale = false;
+                if (random.Next(100) > 75)
+                {
+                    isfemale = true;
+                }
+                var NPC = gen_quest_main.myMod.Npcs[new FormKey(gen_quest_main.myMod.ModKey, NPCTools.GetTemplateNPC(isfemale))].DeepCopy();
+                Npc npc = NPCTools.CloneNPC(gen_quest_main.myMod, NPC);
+
+                //Ranked Info
+                var outfit = GetLowRank_Outfit();
+                npc.Name = "Zealot" + " " + GetLowRank_Name();
+                var gear = GetLowRank_Gear();
+                var lev = new PcLevelMult();
+                lev.LevelMult = 0.5f + ((float)random.NextDouble()/2);
+                npc.Level = lev;
+
+                CreateNPC(Faction, random, isfemale, npc, outfit, gear);
+
+                LowRank.Add(npc);
+            }
+
+            //High Rank
+            for (int i = 0; i < highrank_crewcount; i++)
+            {
+                bool isfemale = false;
+                if (random.Next(100) > 75)
+                {
+                    isfemale = true;
+                }
+                var NPC = gen_quest_main.myMod.Npcs[new FormKey(gen_quest_main.myMod.ModKey, NPCTools.GetTemplateNPC(isfemale))].DeepCopy();
+                Npc npc = NPCTools.CloneNPC(gen_quest_main.myMod, NPC);
+
+                //Ranked Info
+                var outfit = GetHighRank_Outfit();
+                npc.Name = "Zealot" + " " + GetHighRank_Name();
+                var gear = GetHighRank_Gear();
+                var lev = new PcLevelMult();
+                lev.LevelMult = 0.75f + (float)random.NextDouble();
+                npc.Level = lev;
+
+                CreateNPC(Faction, random, isfemale, npc, outfit, gear);
+                HighRank.Add(npc);
+
+            }
+
+            for (int i = 0; i < boss_crewcount; i++)
+            {
+                bool isfemale = false;
+                if (random.Next(100) > 50)
+                {
+                    isfemale = true;
+                }
+                var NPC = gen_quest_main.myMod.Npcs[new FormKey(gen_quest_main.myMod.ModKey, NPCTools.GetTemplateNPC(isfemale))].DeepCopy();
+                Npc npc = NPCTools.CloneNPC(gen_quest_main.myMod, NPC);
+
+                //Ranked Info
+                var outfit = GetBoss_Outfit();
+                npc.Name = "Zealot" + " " + GetBoss_Name();
+                var gear = GetBoss_Gear();
+                var lev = new PcLevelMult();
+                lev.LevelMult = 1 + (float)random.NextDouble();
+                npc.Level = lev;
+
+                CreateNPC(Faction, random, isfemale, npc, outfit, gear);
+                Bosses.Add(npc);
+            }
+        }
+
+        private void CreateNPC(string Faction, Random random, bool isfemale, Npc npc, IFormLinkNullable<IOutfitGetter> outfit, IFormLinkNullable<ILeveledItemGetter> gear)
+        {
+            //Generate Member
+            string Gender = "Male";
+            if (isfemale) Gender = "Female";
+            npc.EditorID = "npc_" + (npc.Name.ToString().ToLower()).Replace(" ", "");
+            npc.Voice = NPCTools.GetVoice(Faction, isfemale);
+            npc.Factions.Clear();
+            npc.Factions.Add(NPCTools.GetFaction(Faction));
+            npc.Weight = new NpcWeight()
+            {
+                Fat = (float)random.NextDouble() /2,
+                Muscular = (float)random.NextDouble(),
+                Thin = (float)random.NextDouble()/2
+            };
+            npc.SpaceOutfit = outfit;
+            npc.EyeColor = NPCTools.GetEyeColour();
+            npc.HairColor = NPCTools.GetHairColour();
+            npc.SkinToneIndex = (byte)random.Next(8);
+            npc.HeadParts.Add(NPCTools.GetHaircut(isfemale));
+            npc.Items = new ExtendedList<ContainerEntry>
+                {
+                    new ContainerEntry() { Item = new ContainerItem() { Item = gear, Count = 1 } },
+                };
+            gen_quest_main.myMod.Npcs.Add(npc);
+        }
+
+        public IFormLinkNullable<IOutfitGetter> GetLowRank_Outfit()
+        {
+            Random random = RandomUtils.random;
+            List<uint> Outfits = new List<uint>
+            {
+                0x00042D85,// Outfit_Worker [OTFT:00042D85]
+                0x000D6FA8,// Outfit_Spacesuit_Varuun_NoHelmetNoBackpack [OTFT:000D6FA8]
+            };
+            IFormLinkNullable<IOutfitGetter> outfit = new FormKey(gen_quest_main.StarfieldModKey, Outfits[random.Next(Outfits.Count)]).ToNullableLink<IOutfitGetter>();
+            return outfit;
+        }
+
+        public IFormLinkNullable<IOutfitGetter> GetHighRank_Outfit()
+        {
+            Random random = RandomUtils.random;
+            List<uint> Outfits = new List<uint>
+            {
+                0x00278715,//Outfit_Spacesuit_Varuun [OTFT:00278715]
+                0x000D6FA8,//Outfit_Spacesuit_Varuun_NoHelmetNoBackpack [OTFT:000D6FA8]
+            };
+            IFormLinkNullable<IOutfitGetter> outfit = new FormKey(gen_quest_main.StarfieldModKey, Outfits[random.Next(Outfits.Count)]).ToNullableLink<IOutfitGetter>();
+            return outfit;
+        }
+
+        public IFormLinkNullable<IOutfitGetter> GetBoss_Outfit()
+        {
+            Random random = RandomUtils.random;
+            List<uint> Outfits = new List<uint>
+            {
+                0x00278715,//Outfit_Spacesuit_Varuun [OTFT:00278715]
+            };
+            IFormLinkNullable<IOutfitGetter> outfit = new FormKey(gen_quest_main.StarfieldModKey, Outfits[random.Next(Outfits.Count)]).ToNullableLink<IOutfitGetter>();
+            return outfit;
+        }
+
+        public string GetLowRank_Name()
+        {
+            Random r = RandomUtils.random;
+            var roles = new List<string>
+            {
+                "Initiate","New Initiate","Sworn Initiate","Bound Initiate",
+                "Acolyte","Temple Acolyte","Flame Acolyte","Serpent Acolyte",
+                "Pilgrim","Armed Pilgrim","Devoted Pilgrim","Wandering Pilgrim",
+                "Disciple","Sworn Disciple","Blade Disciple","Faith Disciple",
+                "Watcher","Gate Watcher","Night Watcher","Flame Watcher",
+                "Seeker","Truth Seeker","Path Seeker","Void Seeker",
+                "Keeper","Relic Keeper","Shrine Keeper","Gate Keeper",
+                "Guard","Temple Guard","Sanctum Guard","Shrine Guard"
+            };
+            return roles[r.Next(roles.Count)];
+        }
+
+        public string GetHighRank_Name()
+        {
+            Random r = RandomUtils.random;
+            var roles = new List<string>
+            {
+                "Crusader","Holy Crusader","Flame Crusader","Void Crusader",
+                "Templar","Sworn Templar","Battle Templar","Elder Templar",
+                "Inquisitor","Grand Inquisitor","Faith Inquisitor","Temple Inquisitor",
+                "Ordained","Ordained Blade","Ordained Flame","Ordained Warden",
+                "Zealot Captain","War Captain","Crusade Captain",
+                "Prelate","Battle Prelate","Senior Prelate"
+            };
+            return roles[r.Next(roles.Count)];
+        }
+
+        public string GetBoss_Name()
+        {
+            Random r = RandomUtils.random;
+            var roles = new List<string>
+            {
+                "High Zealot","Supreme Zealot","Grand Zealot",
+                "Archon","War Archon","Temple Archon","Void Archon",
+                "Prophet","War Prophet","Doom Prophet","Serpent Prophet",
+                "Harbinger","Flame Harbinger","Void Harbinger",
+                "Exarch","Grand Exarch","Battle Exarch",
+                "High Priest","War Priest","Serpent Priest",
+                "Fanatic Lord","Crusade Lord","Temple Lord"
+            };
+            return roles[r.Next(roles.Count)];
+        }
+
+        public IFormLinkNullable<ILeveledItemGetter> GetLowRank_Gear()
+        {
+            Random random = RandomUtils.random;
+            List<uint> gearlist = new List<uint>()
+                {
+                    0x003D0946,//LLI_Spacer_AssaultDefaultRole [LVLI:003D0946]
+                    0x003D0947,//LLI_Spacer_Charger [LVLI:003D0947]
+                    0x003D0948,//LLI_Spacer_Heavy [LVLI:003D0948]
+                    0x003D094B,//LLI_Spacer_Sniper [LVLI:003D094B]
+                    0x003D094A,//LLI_Spacer_Recruit [LVLI:003D094A]
+                };
+            IFormLinkNullable<ILeveledItemGetter> gear = new FormKey(gen_quest_main.StarfieldModKey, gearlist[random.Next(gearlist.Count)]).ToNullableLink<ILeveledItemGetter>();
+            return gear;
+        }
+
+        public IFormLinkNullable<ILeveledItemGetter> GetHighRank_Gear()
+        {
+            Random random = RandomUtils.random;
+            List<uint> gearlist = new List<uint>()
+                {
+                    0x003D0949,//LLI_Spacer_Officer [LVLI:003D0949]
+                    0x003D0946,//LLI_Spacer_AssaultDefaultRole [LVLI:003D0946]
+                    0x003D0948,//LLI_Spacer_Heavy [LVLI:003D0948]
+                    0x003D094B,//LLI_Spacer_Sniper [LVLI:003D094B]
+                };
+            IFormLinkNullable<ILeveledItemGetter> gear = new FormKey(gen_quest_main.StarfieldModKey, gearlist[random.Next(gearlist.Count)]).ToNullableLink<ILeveledItemGetter>();
+            return gear;
+        }
+
+        public IFormLinkNullable<ILeveledItemGetter> GetBoss_Gear()
+        {
+            Random random = RandomUtils.random;
+            List<uint> gearlist = new List<uint>()
+                {
+                    0x003D0949,//LLI_Spacer_Officer [LVLI:003D0949]
+                    0x003D0948,//LLI_Spacer_Heavy [LVLI:003D0948]
+                };
+            IFormLinkNullable<ILeveledItemGetter> gear = new FormKey(gen_quest_main.StarfieldModKey, gearlist[random.Next(gearlist.Count)]).ToNullableLink<ILeveledItemGetter>();
+            return gear;
+        }
+
+        public Npc GetCrewMember(string Room)
+        {
+            Npc selected = null;
+            int roll = RandomUtils.random.Next(100);
+            if (roll > 60)
+            {
+                selected = HighRank[RandomUtils.random.Next(HighRank.Count)];
+            }
+            else
+            {
+                selected = LowRank[RandomUtils.random.Next(LowRank.Count)];
+            }
+            return selected;
+        }
+
+        public Npc GetBoss(string Room)
+        {
+            return Bosses[RandomUtils.random.Next(Bosses.Count)];
+        }
+    }
+}

--- a/Retrograde/Passes/EnemyPass.cs
+++ b/Retrograde/Passes/EnemyPass.cs
@@ -108,6 +108,15 @@ namespace FrankyCLI.Retrograde
                 case "Crimsonfleet":
                     stationFactionCrew = new CrimsonFleetFactionCrew();
                     break;
+                case "Ecliptic":
+                    stationFactionCrew = new EclipticFactionCrew();
+                    break;
+                case "Varuun":
+                    stationFactionCrew = new VaruunFactionCrew();
+                    break;
+                case "Spacer":
+                    stationFactionCrew = new SpacerFactionCrew();
+                    break;
                 default:
                     stationFactionCrew = new CrimsonFleetFactionCrew();
                     break;


### PR DESCRIPTION
Each Retrograde quest faction now has its own crew generation with
faction-appropriate names, outfits, gear, and the EnemyPass switch
statement routes to the correct implementation.

https://claude.ai/code/session_015PQRSrZPkYTduYhNvmy4Q4