### PR TITLE
Add randomised faction name prefixes with 10 alternatives per faction

### DIFF
--- a/Retrograde/FactionMembers/CrimsonFleetFactionCrew.cs
+++ b/Retrograde/FactionMembers/CrimsonFleetFactionCrew.cs
@@ -226,7 +226,11 @@ namespace FrankyCLI.questgen_tools
             var prefixes = new List<string>
             {
                 "Crimson","Fleet","Crimson Fleet","Pirate","Buccaneer",
-                "Corsair","Raider","Marauder","Freebooter","Privateer"
+                "Corsair","Raider","Marauder","Freebooter","Privateer",
+                "Reaver","Plunderer","Cutthroat","Smuggler","Brigand",
+                "Rogue","Outcast","Scourge","Pillager","Blackguard",
+                "Desperado","Swashbuckler","Dread","Renegade","Bandit",
+                "Ravager","Prowler","Skulker","Warmonger","Exile"
             };
             return prefixes[r.Next(prefixes.Count)];
         }

--- a/Retrograde/FactionMembers/CrimsonFleetFactionCrew.cs
+++ b/Retrograde/FactionMembers/CrimsonFleetFactionCrew.cs
@@ -44,7 +44,7 @@ namespace FrankyCLI.questgen_tools
 
                 //Ranked Info
                 var outfit = GetLowRank_Outfit();
-                npc.Name = "Crimson" + " " + GetLowRank_Name();
+                npc.Name = GetFactionPrefix() + " " + GetLowRank_Name();
                 var gear = GetLowRank_Gear();
                 var lev = new PcLevelMult();
                 lev.LevelMult = 0.5f + ((float)random.NextDouble()/2);
@@ -68,7 +68,7 @@ namespace FrankyCLI.questgen_tools
 
                 //Ranked Info
                 var outfit = GetHighRank_Outfit();
-                npc.Name = "Crimson" + " " + GetHighRank_Name();
+                npc.Name = GetFactionPrefix() + " " + GetHighRank_Name();
                 var gear = GetHighRank_Gear();
                 var lev = new PcLevelMult();
                 lev.LevelMult = 0.75f + (float)random.NextDouble();
@@ -91,7 +91,7 @@ namespace FrankyCLI.questgen_tools
 
                 //Ranked Info
                 var outfit = GetBoss_Outfit();
-                npc.Name = "Crimson" + " " + GetBoss_Name();
+                npc.Name = GetFactionPrefix() + " " + GetBoss_Name();
                 var gear = GetBoss_Gear();
                 var lev = new PcLevelMult();
                 lev.LevelMult = 1 + (float)random.NextDouble();
@@ -215,6 +215,17 @@ namespace FrankyCLI.questgen_tools
             };
             IFormLinkNullable<IOutfitGetter> outfit = new FormKey(gen_quest_main.StarfieldModKey, Outfits[random.Next(Outfits.Count)]).ToNullableLink<IOutfitGetter>();
             return outfit;
+        }
+
+        private string GetFactionPrefix()
+        {
+            Random r = RandomUtils.random;
+            var prefixes = new List<string>
+            {
+                "Crimson","Fleet","Crimson Fleet","Pirate","Buccaneer",
+                "Corsair","Raider","Marauder","Freebooter","Privateer"
+            };
+            return prefixes[r.Next(prefixes.Count)];
         }
 
         public string GetLowRank_Name()

--- a/Retrograde/FactionMembers/CrimsonFleetFactionCrew.cs
+++ b/Retrograde/FactionMembers/CrimsonFleetFactionCrew.cs
@@ -17,11 +17,13 @@ namespace FrankyCLI.questgen_tools
         List<Npc> LowRank { get; set; }
         List<Npc> HighRank { get; set; }
         List<Npc> Bosses { get; set; }
+        string FactionName { get; set; }
         public CrimsonFleetFactionCrew()
         {
             string Faction = "Crimsonfleet";
             Random random = RandomUtils.random;
             string Crewname = Faction;
+            FactionName = GetFactionPrefix();
 
             int lowrank_crewcount = 10;
             int highrank_crewcount = 5;
@@ -219,6 +221,7 @@ namespace FrankyCLI.questgen_tools
 
         private string GetFactionPrefix()
         {
+            if (FactionName != null) return FactionName;
             Random r = RandomUtils.random;
             var prefixes = new List<string>
             {

--- a/Retrograde/FactionMembers/EclipticFactionCrew.cs
+++ b/Retrograde/FactionMembers/EclipticFactionCrew.cs
@@ -44,7 +44,7 @@ namespace FrankyCLI.questgen_tools
 
                 //Ranked Info
                 var outfit = GetLowRank_Outfit();
-                npc.Name = "Ecliptic" + " " + GetLowRank_Name();
+                npc.Name = GetFactionPrefix() + " " + GetLowRank_Name();
                 var gear = GetLowRank_Gear();
                 var lev = new PcLevelMult();
                 lev.LevelMult = 0.5f + ((float)random.NextDouble()/2);
@@ -68,7 +68,7 @@ namespace FrankyCLI.questgen_tools
 
                 //Ranked Info
                 var outfit = GetHighRank_Outfit();
-                npc.Name = "Ecliptic" + " " + GetHighRank_Name();
+                npc.Name = GetFactionPrefix() + " " + GetHighRank_Name();
                 var gear = GetHighRank_Gear();
                 var lev = new PcLevelMult();
                 lev.LevelMult = 0.75f + (float)random.NextDouble();
@@ -91,7 +91,7 @@ namespace FrankyCLI.questgen_tools
 
                 //Ranked Info
                 var outfit = GetBoss_Outfit();
-                npc.Name = "Ecliptic" + " " + GetBoss_Name();
+                npc.Name = GetFactionPrefix() + " " + GetBoss_Name();
                 var gear = GetBoss_Gear();
                 var lev = new PcLevelMult();
                 lev.LevelMult = 1 + (float)random.NextDouble();
@@ -211,6 +211,17 @@ namespace FrankyCLI.questgen_tools
             };
             IFormLinkNullable<IOutfitGetter> outfit = new FormKey(gen_quest_main.StarfieldModKey, Outfits[random.Next(Outfits.Count)]).ToNullableLink<IOutfitGetter>();
             return outfit;
+        }
+
+        private string GetFactionPrefix()
+        {
+            Random r = RandomUtils.random;
+            var prefixes = new List<string>
+            {
+                "Ecliptic","Eclipse","Merc","Mercenary","Contractor",
+                "Operative","Hired Gun","Sellsword","Freelancer","Soldier"
+            };
+            return prefixes[r.Next(prefixes.Count)];
         }
 
         public string GetLowRank_Name()

--- a/Retrograde/FactionMembers/EclipticFactionCrew.cs
+++ b/Retrograde/FactionMembers/EclipticFactionCrew.cs
@@ -17,11 +17,13 @@ namespace FrankyCLI.questgen_tools
         List<Npc> LowRank { get; set; }
         List<Npc> HighRank { get; set; }
         List<Npc> Bosses { get; set; }
+        string FactionName { get; set; }
         public EclipticFactionCrew()
         {
             string Faction = "Ecliptic";
             Random random = RandomUtils.random;
             string Crewname = Faction;
+            FactionName = GetFactionPrefix();
 
             int lowrank_crewcount = 10;
             int highrank_crewcount = 5;
@@ -215,6 +217,7 @@ namespace FrankyCLI.questgen_tools
 
         private string GetFactionPrefix()
         {
+            if (FactionName != null) return FactionName;
             Random r = RandomUtils.random;
             var prefixes = new List<string>
             {

--- a/Retrograde/FactionMembers/EclipticFactionCrew.cs
+++ b/Retrograde/FactionMembers/EclipticFactionCrew.cs
@@ -222,7 +222,11 @@ namespace FrankyCLI.questgen_tools
             var prefixes = new List<string>
             {
                 "Ecliptic","Eclipse","Merc","Mercenary","Contractor",
-                "Operative","Hired Gun","Sellsword","Freelancer","Soldier"
+                "Operative","Hired Gun","Sellsword","Freelancer","Soldier",
+                "Professional","Militant","Enforcer","Gunhand","Tactician",
+                "Vanguard","Sentinel","Warden","Striker","Dragoon",
+                "Trooper","Conscript","Ranger","Commando","Legionnaire",
+                "Wardog","Ironside","Partisan","Outrider","Bulwark"
             };
             return prefixes[r.Next(prefixes.Count)];
         }

--- a/Retrograde/FactionMembers/SpacerFactionCrew.cs
+++ b/Retrograde/FactionMembers/SpacerFactionCrew.cs
@@ -222,7 +222,11 @@ namespace FrankyCLI.questgen_tools
             var prefixes = new List<string>
             {
                 "Spacer","Vagrant","Outlaw","Rogue","Bandit",
-                "Scavenger","Drifter","Prowler","Raider","Wretch"
+                "Scavenger","Drifter","Prowler","Raider","Wretch",
+                "Derelict","Squatter","Marauder","Lowlife","Vermin",
+                "Mongrel","Scrapper","Guttersnipe","Wildling","Castoff",
+                "Stray","Skulker","Creeper","Waster","Feral",
+                "Hooligan","Miscreant","Ruffian","Vagrant","Degenerate"
             };
             return prefixes[r.Next(prefixes.Count)];
         }

--- a/Retrograde/FactionMembers/SpacerFactionCrew.cs
+++ b/Retrograde/FactionMembers/SpacerFactionCrew.cs
@@ -44,7 +44,7 @@ namespace FrankyCLI.questgen_tools
 
                 //Ranked Info
                 var outfit = GetLowRank_Outfit();
-                npc.Name = "Spacer" + " " + GetLowRank_Name();
+                npc.Name = GetFactionPrefix() + " " + GetLowRank_Name();
                 var gear = GetLowRank_Gear();
                 var lev = new PcLevelMult();
                 lev.LevelMult = 0.5f + ((float)random.NextDouble()/2);
@@ -68,7 +68,7 @@ namespace FrankyCLI.questgen_tools
 
                 //Ranked Info
                 var outfit = GetHighRank_Outfit();
-                npc.Name = "Spacer" + " " + GetHighRank_Name();
+                npc.Name = GetFactionPrefix() + " " + GetHighRank_Name();
                 var gear = GetHighRank_Gear();
                 var lev = new PcLevelMult();
                 lev.LevelMult = 0.75f + (float)random.NextDouble();
@@ -91,7 +91,7 @@ namespace FrankyCLI.questgen_tools
 
                 //Ranked Info
                 var outfit = GetBoss_Outfit();
-                npc.Name = "Spacer" + " " + GetBoss_Name();
+                npc.Name = GetFactionPrefix() + " " + GetBoss_Name();
                 var gear = GetBoss_Gear();
                 var lev = new PcLevelMult();
                 lev.LevelMult = 1 + (float)random.NextDouble();
@@ -211,6 +211,17 @@ namespace FrankyCLI.questgen_tools
             };
             IFormLinkNullable<IOutfitGetter> outfit = new FormKey(gen_quest_main.StarfieldModKey, Outfits[random.Next(Outfits.Count)]).ToNullableLink<IOutfitGetter>();
             return outfit;
+        }
+
+        private string GetFactionPrefix()
+        {
+            Random r = RandomUtils.random;
+            var prefixes = new List<string>
+            {
+                "Spacer","Vagrant","Outlaw","Rogue","Bandit",
+                "Scavenger","Drifter","Prowler","Raider","Wretch"
+            };
+            return prefixes[r.Next(prefixes.Count)];
         }
 
         public string GetLowRank_Name()

--- a/Retrograde/FactionMembers/SpacerFactionCrew.cs
+++ b/Retrograde/FactionMembers/SpacerFactionCrew.cs
@@ -17,11 +17,13 @@ namespace FrankyCLI.questgen_tools
         List<Npc> LowRank { get; set; }
         List<Npc> HighRank { get; set; }
         List<Npc> Bosses { get; set; }
+        string FactionName { get; set; }
         public SpacerFactionCrew()
         {
             string Faction = "Spacer";
             Random random = RandomUtils.random;
             string Crewname = Faction;
+            FactionName = GetFactionPrefix();
 
             int lowrank_crewcount = 10;
             int highrank_crewcount = 5;
@@ -215,6 +217,7 @@ namespace FrankyCLI.questgen_tools
 
         private string GetFactionPrefix()
         {
+            if (FactionName != null) return FactionName;
             Random r = RandomUtils.random;
             var prefixes = new List<string>
             {

--- a/Retrograde/FactionMembers/VaruunFactionCrew.cs
+++ b/Retrograde/FactionMembers/VaruunFactionCrew.cs
@@ -222,7 +222,11 @@ namespace FrankyCLI.questgen_tools
             var prefixes = new List<string>
             {
                 "Zealot","Varuun","Fanatic","Believer","Devout",
-                "Faithful","Chosen","Pilgrim","Disciple","Adherent"
+                "Faithful","Chosen","Pilgrim","Disciple","Adherent",
+                "Acolyte","Penitent","Ascendant","Prophet","Herald",
+                "Ordained","Anointed","Sanctified","Seeker","Witness",
+                "Evangel","Crusader","Templar","Inquisitor","Harbinger",
+                "Apostle","Confessor","Mystic","Revenant","Oracle"
             };
             return prefixes[r.Next(prefixes.Count)];
         }

--- a/Retrograde/FactionMembers/VaruunFactionCrew.cs
+++ b/Retrograde/FactionMembers/VaruunFactionCrew.cs
@@ -17,11 +17,13 @@ namespace FrankyCLI.questgen_tools
         List<Npc> LowRank { get; set; }
         List<Npc> HighRank { get; set; }
         List<Npc> Bosses { get; set; }
+        string FactionName { get; set; }
         public VaruunFactionCrew()
         {
             string Faction = "Varuun";
             Random random = RandomUtils.random;
             string Crewname = Faction;
+            FactionName = GetFactionPrefix();
 
             int lowrank_crewcount = 10;
             int highrank_crewcount = 5;
@@ -215,6 +217,7 @@ namespace FrankyCLI.questgen_tools
 
         private string GetFactionPrefix()
         {
+            if (FactionName != null) return FactionName;
             Random r = RandomUtils.random;
             var prefixes = new List<string>
             {

--- a/Retrograde/FactionMembers/VaruunFactionCrew.cs
+++ b/Retrograde/FactionMembers/VaruunFactionCrew.cs
@@ -44,7 +44,7 @@ namespace FrankyCLI.questgen_tools
 
                 //Ranked Info
                 var outfit = GetLowRank_Outfit();
-                npc.Name = "Zealot" + " " + GetLowRank_Name();
+                npc.Name = GetFactionPrefix() + " " + GetLowRank_Name();
                 var gear = GetLowRank_Gear();
                 var lev = new PcLevelMult();
                 lev.LevelMult = 0.5f + ((float)random.NextDouble()/2);
@@ -68,7 +68,7 @@ namespace FrankyCLI.questgen_tools
 
                 //Ranked Info
                 var outfit = GetHighRank_Outfit();
-                npc.Name = "Zealot" + " " + GetHighRank_Name();
+                npc.Name = GetFactionPrefix() + " " + GetHighRank_Name();
                 var gear = GetHighRank_Gear();
                 var lev = new PcLevelMult();
                 lev.LevelMult = 0.75f + (float)random.NextDouble();
@@ -91,7 +91,7 @@ namespace FrankyCLI.questgen_tools
 
                 //Ranked Info
                 var outfit = GetBoss_Outfit();
-                npc.Name = "Zealot" + " " + GetBoss_Name();
+                npc.Name = GetFactionPrefix() + " " + GetBoss_Name();
                 var gear = GetBoss_Gear();
                 var lev = new PcLevelMult();
                 lev.LevelMult = 1 + (float)random.NextDouble();
@@ -211,6 +211,17 @@ namespace FrankyCLI.questgen_tools
             };
             IFormLinkNullable<IOutfitGetter> outfit = new FormKey(gen_quest_main.StarfieldModKey, Outfits[random.Next(Outfits.Count)]).ToNullableLink<IOutfitGetter>();
             return outfit;
+        }
+
+        private string GetFactionPrefix()
+        {
+            Random r = RandomUtils.random;
+            var prefixes = new List<string>
+            {
+                "Zealot","Varuun","Fanatic","Believer","Devout",
+                "Faithful","Chosen","Pilgrim","Disciple","Adherent"
+            };
+            return prefixes[r.Next(prefixes.Count)];
         }
 
         public string GetLowRank_Name()


### PR DESCRIPTION
Replaces hardcoded prefixes (Crimson, Ecliptic, Zealot, Spacer) with a GetFactionPrefix() method that randomly selects from 10 thematic options.

https://claude.ai/code/session_015PQRSrZPkYTduYhNvmy4Q4