### PR TITLE
Split faction outfits into DefaultOutfit and SpaceOutfit

### DIFF
--- a/Retrograde/FactionMembers/CrimsonFleetFactionCrew.cs
+++ b/Retrograde/FactionMembers/CrimsonFleetFactionCrew.cs
@@ -46,13 +46,14 @@ namespace FrankyCLI.questgen_tools
 
                 //Ranked Info
                 var outfit = GetLowRank_Outfit();
+                var spaceOutfit = GetLowRank_SpaceOutfit();
                 npc.Name = GetFactionPrefix() + " " + GetLowRank_Name();
                 var gear = GetLowRank_Gear();
                 var lev = new PcLevelMult();
                 lev.LevelMult = 0.5f + ((float)random.NextDouble()/2);
                 npc.Level = lev;
 
-                CreateNPC(Faction, random, isfemale, npc, outfit, gear);
+                CreateNPC(Faction, random, isfemale, npc, outfit, spaceOutfit, gear);
 
                 LowRank.Add(npc);
             }
@@ -70,13 +71,14 @@ namespace FrankyCLI.questgen_tools
 
                 //Ranked Info
                 var outfit = GetHighRank_Outfit();
+                var spaceOutfit = GetHighRank_SpaceOutfit();
                 npc.Name = GetFactionPrefix() + " " + GetHighRank_Name();
                 var gear = GetHighRank_Gear();
                 var lev = new PcLevelMult();
                 lev.LevelMult = 0.75f + (float)random.NextDouble();
                 npc.Level = lev;
 
-                CreateNPC(Faction, random, isfemale, npc, outfit, gear);
+                CreateNPC(Faction, random, isfemale, npc, outfit, spaceOutfit, gear);
                 HighRank.Add(npc);
 
             }
@@ -93,18 +95,19 @@ namespace FrankyCLI.questgen_tools
 
                 //Ranked Info
                 var outfit = GetBoss_Outfit();
+                var spaceOutfit = GetBoss_SpaceOutfit();
                 npc.Name = GetFactionPrefix() + " " + GetBoss_Name();
                 var gear = GetBoss_Gear();
                 var lev = new PcLevelMult();
                 lev.LevelMult = 1 + (float)random.NextDouble();
                 npc.Level = lev;
 
-                CreateNPC(Faction, random, isfemale, npc, outfit, gear);
+                CreateNPC(Faction, random, isfemale, npc, outfit, spaceOutfit, gear);
                 Bosses.Add(npc);
             }
         }
 
-        private void CreateNPC(string Faction, Random random, bool isfemale, Npc npc, IFormLinkNullable<IOutfitGetter> outfit, IFormLinkNullable<ILeveledItemGetter> gear)
+        private void CreateNPC(string Faction, Random random, bool isfemale, Npc npc, IFormLinkNullable<IOutfitGetter> outfit, IFormLinkNullable<IOutfitGetter> spaceOutfit, IFormLinkNullable<ILeveledItemGetter> gear)
         {
             //Generate Member
             string Gender = "Male";
@@ -119,7 +122,8 @@ namespace FrankyCLI.questgen_tools
                 Muscular = (float)random.NextDouble(),
                 Thin = (float)random.NextDouble()/2
             };
-            npc.SpaceOutfit = outfit;
+            npc.DefaultOutfit = outfit;
+            npc.SpaceOutfit = spaceOutfit;
             npc.EyeColor = NPCTools.GetEyeColour();
             npc.HairColor = NPCTools.GetHairColour();
             npc.SkinToneIndex = (byte)random.Next(8);
@@ -280,17 +284,32 @@ namespace FrankyCLI.questgen_tools
 
         public IFormLinkNullable<IOutfitGetter> GetHighRank_Outfit()
         {
+            return FormLinkNullable<IOutfitGetter>.Null;
+        }
+
+        public IFormLinkNullable<IOutfitGetter> GetBoss_Outfit()
+        {
+            return FormLinkNullable<IOutfitGetter>.Null;
+        }
+
+        public IFormLinkNullable<IOutfitGetter> GetLowRank_SpaceOutfit()
+        {
+            return FormLinkNullable<IOutfitGetter>.Null;
+        }
+
+        public IFormLinkNullable<IOutfitGetter> GetHighRank_SpaceOutfit()
+        {
             Random random = RandomUtils.random;
             List<uint> Outfits = new List<uint>
             {
                 0x00018DCF,//Outfit_Spacesuit_CrimsonFleet [OTFT:00018DCF]
-                0x00279225//Outfit_Spacesuit_CrimsonFleet_NoHelmet [OTFT:00279225]                
+                0x00279225//Outfit_Spacesuit_CrimsonFleet_NoHelmet [OTFT:00279225]
             };
             IFormLinkNullable<IOutfitGetter> outfit = new FormKey(gen_quest_main.StarfieldModKey, Outfits[random.Next(Outfits.Count)]).ToNullableLink<IOutfitGetter>();
             return outfit;
         }
 
-        public IFormLinkNullable<IOutfitGetter> GetBoss_Outfit()
+        public IFormLinkNullable<IOutfitGetter> GetBoss_SpaceOutfit()
         {
             Random random = RandomUtils.random;
             List<uint> Outfits = new List<uint>

--- a/Retrograde/FactionMembers/EclipticFactionCrew.cs
+++ b/Retrograde/FactionMembers/EclipticFactionCrew.cs
@@ -46,13 +46,14 @@ namespace FrankyCLI.questgen_tools
 
                 //Ranked Info
                 var outfit = GetLowRank_Outfit();
+                var spaceOutfit = GetLowRank_SpaceOutfit();
                 npc.Name = GetFactionPrefix() + " " + GetLowRank_Name();
                 var gear = GetLowRank_Gear();
                 var lev = new PcLevelMult();
                 lev.LevelMult = 0.5f + ((float)random.NextDouble()/2);
                 npc.Level = lev;
 
-                CreateNPC(Faction, random, isfemale, npc, outfit, gear);
+                CreateNPC(Faction, random, isfemale, npc, outfit, spaceOutfit, gear);
 
                 LowRank.Add(npc);
             }
@@ -70,13 +71,14 @@ namespace FrankyCLI.questgen_tools
 
                 //Ranked Info
                 var outfit = GetHighRank_Outfit();
+                var spaceOutfit = GetHighRank_SpaceOutfit();
                 npc.Name = GetFactionPrefix() + " " + GetHighRank_Name();
                 var gear = GetHighRank_Gear();
                 var lev = new PcLevelMult();
                 lev.LevelMult = 0.75f + (float)random.NextDouble();
                 npc.Level = lev;
 
-                CreateNPC(Faction, random, isfemale, npc, outfit, gear);
+                CreateNPC(Faction, random, isfemale, npc, outfit, spaceOutfit, gear);
                 HighRank.Add(npc);
 
             }
@@ -93,18 +95,19 @@ namespace FrankyCLI.questgen_tools
 
                 //Ranked Info
                 var outfit = GetBoss_Outfit();
+                var spaceOutfit = GetBoss_SpaceOutfit();
                 npc.Name = GetFactionPrefix() + " " + GetBoss_Name();
                 var gear = GetBoss_Gear();
                 var lev = new PcLevelMult();
                 lev.LevelMult = 1 + (float)random.NextDouble();
                 npc.Level = lev;
 
-                CreateNPC(Faction, random, isfemale, npc, outfit, gear);
+                CreateNPC(Faction, random, isfemale, npc, outfit, spaceOutfit, gear);
                 Bosses.Add(npc);
             }
         }
 
-        private void CreateNPC(string Faction, Random random, bool isfemale, Npc npc, IFormLinkNullable<IOutfitGetter> outfit, IFormLinkNullable<ILeveledItemGetter> gear)
+        private void CreateNPC(string Faction, Random random, bool isfemale, Npc npc, IFormLinkNullable<IOutfitGetter> outfit, IFormLinkNullable<IOutfitGetter> spaceOutfit, IFormLinkNullable<ILeveledItemGetter> gear)
         {
             //Generate Member
             string Gender = "Male";
@@ -119,7 +122,8 @@ namespace FrankyCLI.questgen_tools
                 Muscular = (float)random.NextDouble(),
                 Thin = (float)random.NextDouble()/2
             };
-            npc.SpaceOutfit = outfit;
+            npc.DefaultOutfit = outfit;
+            npc.SpaceOutfit = spaceOutfit;
             npc.EyeColor = NPCTools.GetEyeColour();
             npc.HairColor = NPCTools.GetHairColour();
             npc.SkinToneIndex = (byte)random.Next(8);
@@ -270,6 +274,21 @@ namespace FrankyCLI.questgen_tools
 
         public IFormLinkNullable<IOutfitGetter> GetHighRank_Outfit()
         {
+            return FormLinkNullable<IOutfitGetter>.Null;
+        }
+
+        public IFormLinkNullable<IOutfitGetter> GetBoss_Outfit()
+        {
+            return FormLinkNullable<IOutfitGetter>.Null;
+        }
+
+        public IFormLinkNullable<IOutfitGetter> GetLowRank_SpaceOutfit()
+        {
+            return FormLinkNullable<IOutfitGetter>.Null;
+        }
+
+        public IFormLinkNullable<IOutfitGetter> GetHighRank_SpaceOutfit()
+        {
             Random random = RandomUtils.random;
             List<uint> Outfits = new List<uint>
             {
@@ -281,7 +300,7 @@ namespace FrankyCLI.questgen_tools
             return outfit;
         }
 
-        public IFormLinkNullable<IOutfitGetter> GetBoss_Outfit()
+        public IFormLinkNullable<IOutfitGetter> GetBoss_SpaceOutfit()
         {
             Random random = RandomUtils.random;
             List<uint> Outfits = new List<uint>

--- a/Retrograde/FactionMembers/IFactionMembers.cs
+++ b/Retrograde/FactionMembers/IFactionMembers.cs
@@ -20,6 +20,10 @@ namespace FrankyCLI.Retrograde.FactionMembers
         IFormLinkNullable<IOutfitGetter> GetHighRank_Outfit();
         IFormLinkNullable<IOutfitGetter> GetBoss_Outfit();
 
+        IFormLinkNullable<IOutfitGetter> GetLowRank_SpaceOutfit();
+        IFormLinkNullable<IOutfitGetter> GetHighRank_SpaceOutfit();
+        IFormLinkNullable<IOutfitGetter> GetBoss_SpaceOutfit();
+
         IFormLinkNullable<ILeveledItemGetter> GetLowRank_Gear();
         IFormLinkNullable<ILeveledItemGetter> GetHighRank_Gear();
         IFormLinkNullable<ILeveledItemGetter> GetBoss_Gear();

--- a/Retrograde/FactionMembers/SpacerFactionCrew.cs
+++ b/Retrograde/FactionMembers/SpacerFactionCrew.cs
@@ -46,13 +46,14 @@ namespace FrankyCLI.questgen_tools
 
                 //Ranked Info
                 var outfit = GetLowRank_Outfit();
+                var spaceOutfit = GetLowRank_SpaceOutfit();
                 npc.Name = GetFactionPrefix() + " " + GetLowRank_Name();
                 var gear = GetLowRank_Gear();
                 var lev = new PcLevelMult();
                 lev.LevelMult = 0.5f + ((float)random.NextDouble()/2);
                 npc.Level = lev;
 
-                CreateNPC(Faction, random, isfemale, npc, outfit, gear);
+                CreateNPC(Faction, random, isfemale, npc, outfit, spaceOutfit, gear);
 
                 LowRank.Add(npc);
             }
@@ -70,13 +71,14 @@ namespace FrankyCLI.questgen_tools
 
                 //Ranked Info
                 var outfit = GetHighRank_Outfit();
+                var spaceOutfit = GetHighRank_SpaceOutfit();
                 npc.Name = GetFactionPrefix() + " " + GetHighRank_Name();
                 var gear = GetHighRank_Gear();
                 var lev = new PcLevelMult();
                 lev.LevelMult = 0.75f + (float)random.NextDouble();
                 npc.Level = lev;
 
-                CreateNPC(Faction, random, isfemale, npc, outfit, gear);
+                CreateNPC(Faction, random, isfemale, npc, outfit, spaceOutfit, gear);
                 HighRank.Add(npc);
 
             }
@@ -93,18 +95,19 @@ namespace FrankyCLI.questgen_tools
 
                 //Ranked Info
                 var outfit = GetBoss_Outfit();
+                var spaceOutfit = GetBoss_SpaceOutfit();
                 npc.Name = GetFactionPrefix() + " " + GetBoss_Name();
                 var gear = GetBoss_Gear();
                 var lev = new PcLevelMult();
                 lev.LevelMult = 1 + (float)random.NextDouble();
                 npc.Level = lev;
 
-                CreateNPC(Faction, random, isfemale, npc, outfit, gear);
+                CreateNPC(Faction, random, isfemale, npc, outfit, spaceOutfit, gear);
                 Bosses.Add(npc);
             }
         }
 
-        private void CreateNPC(string Faction, Random random, bool isfemale, Npc npc, IFormLinkNullable<IOutfitGetter> outfit, IFormLinkNullable<ILeveledItemGetter> gear)
+        private void CreateNPC(string Faction, Random random, bool isfemale, Npc npc, IFormLinkNullable<IOutfitGetter> outfit, IFormLinkNullable<IOutfitGetter> spaceOutfit, IFormLinkNullable<ILeveledItemGetter> gear)
         {
             //Generate Member
             string Gender = "Male";
@@ -119,7 +122,8 @@ namespace FrankyCLI.questgen_tools
                 Muscular = (float)random.NextDouble(),
                 Thin = (float)random.NextDouble()/2
             };
-            npc.SpaceOutfit = outfit;
+            npc.DefaultOutfit = outfit;
+            npc.SpaceOutfit = spaceOutfit;
             npc.EyeColor = NPCTools.GetEyeColour();
             npc.HairColor = NPCTools.GetHairColour();
             npc.SkinToneIndex = (byte)random.Next(8);
@@ -273,6 +277,21 @@ namespace FrankyCLI.questgen_tools
 
         public IFormLinkNullable<IOutfitGetter> GetHighRank_Outfit()
         {
+            return FormLinkNullable<IOutfitGetter>.Null;
+        }
+
+        public IFormLinkNullable<IOutfitGetter> GetBoss_Outfit()
+        {
+            return FormLinkNullable<IOutfitGetter>.Null;
+        }
+
+        public IFormLinkNullable<IOutfitGetter> GetLowRank_SpaceOutfit()
+        {
+            return FormLinkNullable<IOutfitGetter>.Null;
+        }
+
+        public IFormLinkNullable<IOutfitGetter> GetHighRank_SpaceOutfit()
+        {
             Random random = RandomUtils.random;
             List<uint> Outfits = new List<uint>
             {
@@ -282,7 +301,7 @@ namespace FrankyCLI.questgen_tools
             return outfit;
         }
 
-        public IFormLinkNullable<IOutfitGetter> GetBoss_Outfit()
+        public IFormLinkNullable<IOutfitGetter> GetBoss_SpaceOutfit()
         {
             Random random = RandomUtils.random;
             List<uint> Outfits = new List<uint>

--- a/Retrograde/FactionMembers/VaruunFactionCrew.cs
+++ b/Retrograde/FactionMembers/VaruunFactionCrew.cs
@@ -46,13 +46,14 @@ namespace FrankyCLI.questgen_tools
 
                 //Ranked Info
                 var outfit = GetLowRank_Outfit();
+                var spaceOutfit = GetLowRank_SpaceOutfit();
                 npc.Name = GetFactionPrefix() + " " + GetLowRank_Name();
                 var gear = GetLowRank_Gear();
                 var lev = new PcLevelMult();
                 lev.LevelMult = 0.5f + ((float)random.NextDouble()/2);
                 npc.Level = lev;
 
-                CreateNPC(Faction, random, isfemale, npc, outfit, gear);
+                CreateNPC(Faction, random, isfemale, npc, outfit, spaceOutfit, gear);
 
                 LowRank.Add(npc);
             }
@@ -70,13 +71,14 @@ namespace FrankyCLI.questgen_tools
 
                 //Ranked Info
                 var outfit = GetHighRank_Outfit();
+                var spaceOutfit = GetHighRank_SpaceOutfit();
                 npc.Name = GetFactionPrefix() + " " + GetHighRank_Name();
                 var gear = GetHighRank_Gear();
                 var lev = new PcLevelMult();
                 lev.LevelMult = 0.75f + (float)random.NextDouble();
                 npc.Level = lev;
 
-                CreateNPC(Faction, random, isfemale, npc, outfit, gear);
+                CreateNPC(Faction, random, isfemale, npc, outfit, spaceOutfit, gear);
                 HighRank.Add(npc);
 
             }
@@ -93,18 +95,19 @@ namespace FrankyCLI.questgen_tools
 
                 //Ranked Info
                 var outfit = GetBoss_Outfit();
+                var spaceOutfit = GetBoss_SpaceOutfit();
                 npc.Name = GetFactionPrefix() + " " + GetBoss_Name();
                 var gear = GetBoss_Gear();
                 var lev = new PcLevelMult();
                 lev.LevelMult = 1 + (float)random.NextDouble();
                 npc.Level = lev;
 
-                CreateNPC(Faction, random, isfemale, npc, outfit, gear);
+                CreateNPC(Faction, random, isfemale, npc, outfit, spaceOutfit, gear);
                 Bosses.Add(npc);
             }
         }
 
-        private void CreateNPC(string Faction, Random random, bool isfemale, Npc npc, IFormLinkNullable<IOutfitGetter> outfit, IFormLinkNullable<ILeveledItemGetter> gear)
+        private void CreateNPC(string Faction, Random random, bool isfemale, Npc npc, IFormLinkNullable<IOutfitGetter> outfit, IFormLinkNullable<IOutfitGetter> spaceOutfit, IFormLinkNullable<ILeveledItemGetter> gear)
         {
             //Generate Member
             string Gender = "Male";
@@ -119,7 +122,8 @@ namespace FrankyCLI.questgen_tools
                 Muscular = (float)random.NextDouble(),
                 Thin = (float)random.NextDouble()/2
             };
-            npc.SpaceOutfit = outfit;
+            npc.DefaultOutfit = outfit;
+            npc.SpaceOutfit = spaceOutfit;
             npc.EyeColor = NPCTools.GetEyeColour();
             npc.HairColor = NPCTools.GetHairColour();
             npc.SkinToneIndex = (byte)random.Next(8);
@@ -259,6 +263,21 @@ namespace FrankyCLI.questgen_tools
 
         public IFormLinkNullable<IOutfitGetter> GetLowRank_Outfit()
         {
+            return FormLinkNullable<IOutfitGetter>.Null;
+        }
+
+        public IFormLinkNullable<IOutfitGetter> GetHighRank_Outfit()
+        {
+            return FormLinkNullable<IOutfitGetter>.Null;
+        }
+
+        public IFormLinkNullable<IOutfitGetter> GetBoss_Outfit()
+        {
+            return FormLinkNullable<IOutfitGetter>.Null;
+        }
+
+        public IFormLinkNullable<IOutfitGetter> GetLowRank_SpaceOutfit()
+        {
             Random random = RandomUtils.random;
             List<uint> Outfits = new List<uint>
             {
@@ -268,7 +287,7 @@ namespace FrankyCLI.questgen_tools
             return outfit;
         }
 
-        public IFormLinkNullable<IOutfitGetter> GetHighRank_Outfit()
+        public IFormLinkNullable<IOutfitGetter> GetHighRank_SpaceOutfit()
         {
             Random random = RandomUtils.random;
             List<uint> Outfits = new List<uint>
@@ -280,7 +299,7 @@ namespace FrankyCLI.questgen_tools
             return outfit;
         }
 
-        public IFormLinkNullable<IOutfitGetter> GetBoss_Outfit()
+        public IFormLinkNullable<IOutfitGetter> GetBoss_SpaceOutfit()
         {
             Random random = RandomUtils.random;
             List<uint> Outfits = new List<uint>


### PR DESCRIPTION
Separate space outfits from clothes in IFactionMembers. Ranks wearing
only clothes (Spacer/Ecliptic/CrimsonFleet low rank) now set SpaceOutfit
to null and assign clothes to DefaultOutfit. Ranks wearing spacesuits
set DefaultOutfit to null. Varuun uses spacesuits at all ranks.

https://claude.ai/code/session_01QNsuPKiAuPc29YBpx3P3t6