### PR TITLE
Add Iron Warden lore file and CLAUDE.md with lore generation guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# FrankyCLI - Starfield Bounty Quest Generator
+
+## Project Overview
+This is a C# tool that procedurally generates bounty-hunting quests for Starfield using AI-driven lore and prompt systems. It uses the Mutagen library for Bethesda plugin generation.
+
+## Lore System
+
+When generating or editing anything that needs narrative content, lore, quest text, flavour text, character profiles, mission briefings, or any in-universe writing, you MUST reference the existing lore files and follow their structure.
+
+### Lore File Location
+All lore files live in `questgen_quests/Lorefiles/` as `.md` files.
+
+### Lore File Structure
+Every lore file uses this exact XML-like structure:
+
+```
+<LoreContext>
+    <Summary>
+        <StorySummary>
+            3-5 sentence overview: who the fugitive is, why they're hunted,
+            and the tone of the pursuit.
+        </StorySummary>
+    </Summary>
+
+    <LorePrompts>
+        <TargetProfile>   - Background, skills, affiliations, triggering crime, rumors, emotional weight
+        <Rumors>           - Conflicting accounts, strange sightings, exaggerated tales
+        <Leads>            - Physical evidence, testimony, locations visited
+        <Locations>        - Hideouts, environments, hazards reflecting the target's strategy
+        <Motives>          - Guilt, fear, ideology, hidden connections, personal stakes
+        <Threats>          - Rival hunters, traps, environmental dangers
+        <MysteryElements>  - Unanswered questions, inconsistencies, hints of something larger
+    </LorePrompts>
+</LoreContext>
+```
+
+### Rules for Creating New Lore Files
+- Each lore file defines ONE fugitive/bounty target with a unique archetype and narrative hook.
+- The `<StorySummary>` sets the tone for the entire file. It should be evocative but concise.
+- Each `<LorePrompts>` subsection is a generation directive ("Generate 1 lore entry about...") that the AI fills at runtime.
+- Lore must be original, self-contained, and open-ended enough to generate many different quests.
+- Tone: Starfield-adjacent sci-fi. Factions, frontier settlements, grav jumps, Colony War history are all fair game.
+- No copyrighted characters or settings. Fully original content only.
+- Avoid generic/vague archetypes. Each target should have a specific identity, a concrete triggering event, and motives that create moral complexity.
+- See existing files (e.g., `NeonGhost.md`, `STARVEDPROPHET.md`, `IronWarden.md`, `Gilded_Viper_Lore.md`) for reference.
+
+### How Lore Is Used in Code
+- `PromptManager.cs` loads a random lore file via `LoadRandomLoreFile()` and stores it in the static `LoreContext` field.
+- Every prompt method (`GetQuestName`, `GetActivatorName`, `GetLogMessage`, `GetPickupMessage`, etc.) injects `LoreContext` into the AI prompt between `<LoreContext>` and `</LoreContext>` tags.
+- `GenerateLoreFile()` in `PromptManager.cs` can also generate lore files dynamically via AI, using a simpler structure (Summary, StorySeed, TargetProfile, Motives).
+- When writing or modifying prompt methods that produce in-universe text, always ensure they reference `LoreContext` for narrative consistency.
+
+## Key Directories
+- `questgen_tools/` - Core quest generation logic and utilities
+- `questgen_tools/Utils/` - PromptManager, AITools, and other utilities
+- `questgen_quests/` - Quest definitions and lore files
+- `questgen_quests/Lorefiles/` - All lore files (`.md`)

--- a/questgen_quests/Lorefiles/IronWarden.md
+++ b/questgen_quests/Lorefiles/IronWarden.md
@@ -1,0 +1,95 @@
+<LoreContext>
+
+    <Summary>
+        <StorySummary>
+            Deep in the Settled Systems, whispers circulate about a rogue military commander
+            known as **The Iron Warden**—a decorated UC Navy strategist who vanished after
+            orchestrating the destruction of a classified forward operating base.
+
+            The UC has issued a sealed bounty, restricted to vetted hunters only.
+
+            The Warden moves between decommissioned military installations, frontier garrison
+            towns, and smuggler waypoints along old Colony War supply routes. Behind them:
+            missing munitions, disabled surveillance grids, and soldiers who refuse to speak.
+
+            Hunters on the Warden's trail discover a web of buried war crimes, falsified
+            mission reports, and stolen prototype weapons. Each lead suggests the same
+            uncomfortable truth: the Warden isn't running from justice—they're carrying out
+            a mission no one authorized.
+        </StorySummary>
+    </Summary>
+
+
+    <LorePrompts>
+
+        <TargetProfile>
+            Generate 1 lore entry about the Iron Warden. Include:
+            - Their background as a UC Navy tactical commander, siege specialist, or
+              forward operations planner during the Colony War.
+            - The event that triggered the bounty: destruction of a classified base,
+              theft of experimental ordnance, or execution of soldiers under their command.
+            - Rumors about whether the Warden acts out of guilt, ideology, or a secret
+              directive from a faction that no longer officially exists.
+            - The emotional weight behind their desertion: survivor's guilt, rage at
+              command failures, or knowledge of atrocities covered up by the brass.
+        </TargetProfile>
+
+        <Rumors>
+            Generate 1 set of rumors about the Iron Warden. Include:
+            - Conflicting accounts from discharged veterans, frontier settlers, and arms dealers.
+            - Reports of derelict military outposts reactivated overnight with no explanation.
+            - Claims the Warden still commands a small, fiercely loyal squad of deserters
+              operating under old Colony War call signs.
+        </Rumors>
+
+        <Leads>
+            Generate 1 lore entry describing the trail hunters follow. Include:
+            - Damaged dog tags, redacted mission briefings, and partially wiped nav logs.
+            - Testimony from garrison personnel who received coded transmissions before
+              equipment went missing.
+            - Weapon caches hidden along forgotten Colony War evacuation corridors.
+        </Leads>
+
+        <Locations>
+            Generate 1 lore entry about places tied to the Warden's movements. Include:
+            - Abandoned forward operating bases, derelict shipyards, and frontier
+              munitions depots.
+            - How each location reflects the Warden's military discipline—fortified,
+              booby-trapped, and stripped of useful intel before departure.
+            - Environmental hazards: unstable reactor cores, corroded hull breaches,
+              or active minefields from the Colony War era.
+        </Locations>
+
+        <Motives>
+            Generate 1 motive for why the Warden deserted. Include:
+            - Knowledge of a classified atrocity committed during the Colony War that
+              command buried in sealed records.
+            - A belief that the current military leadership will repeat the same mistakes
+              unless forced to confront the past.
+            - A personal vendetta against a senior officer who sacrificed the Warden's
+              unit to cover a strategic blunder.
+            - Possession of evidence that could destabilize UC military authority if
+              made public.
+        </Motives>
+
+        <Threats>
+            Generate 1 lore entry about dangers tied to the pursuit. Include:
+            - UC military intelligence operatives working to reach the Warden before
+              bounty hunters do—with orders to silence, not capture.
+            - Booby-trapped supply caches and automated turret systems left active.
+            - Rival hunters hired by arms dealers who want the stolen prototypes
+              for themselves.
+        </Threats>
+
+        <MysteryElements>
+            Generate 1 subtle mystery element woven through the hunt. Include:
+            - Sealed Colony War records that contradict the official bounty justification.
+            - Evidence that the classified base the Warden destroyed was conducting
+              illegal weapons research on civilian populations.
+            - Strange transmissions on old military frequencies suggesting the Warden
+              is trying to warn someone—or coordinate something.
+        </MysteryElements>
+
+    </LorePrompts>
+
+</LoreContext>


### PR DESCRIPTION
New lore file introduces a rogue UC Navy commander archetype with Colony War
backstory. CLAUDE.md documents the lore file structure and instructs Claude
to reference lore files when generating any in-universe narrative content.

https://claude.ai/code/session_01KVUDcynVVvVoNzXR96qU2L