### PR TITLE
Add duplicate room penalty to scoring system

### DIFF
--- a/Retrograde.Library/Core/ScoringUtil.cs
+++ b/Retrograde.Library/Core/ScoringUtil.cs
@@ -1,4 +1,6 @@
+using Mutagen.Bethesda.Plugins;
 using Retrograde.Passes;
+using Retrograde.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,7 +9,7 @@ namespace Retrograde;
 
 public static class ScoringUtil
 {
-    public static PlanScore ScorePlan(ScoringSystem scoringSystem, int roomsPlaced, int bridgeablePairs, int bridgingOverlapCount = 0, int newConnectors = 0, double area = 0, double clustering = 0, double sizeDiversityPenalty = 0, double roomReuseScore = 0, double connectorViability = 0)
+    public static PlanScore ScorePlan(ScoringSystem scoringSystem, int roomsPlaced, int bridgeablePairs, int bridgingOverlapCount = 0, int newConnectors = 0, double area = 0, double clustering = 0, double sizeDiversityPenalty = 0, double roomReuseScore = 0, double connectorViability = 0, double duplicateRoomPenalty = 0)
     {
         var components = new Dictionary<string, double>
         {
@@ -19,7 +21,8 @@ public static class ScoringUtil
             { "Clustering", (clustering/10) * scoringSystem.ClusteringWeight },
             { "SizeDiversity", sizeDiversityPenalty * scoringSystem.SizeDiversityWeight },
             { "RoomReuse", roomReuseScore * scoringSystem.RoomReuseWeight },
-            { "ConnectorViability", connectorViability * scoringSystem.ConnectorViabilityWeight }
+            { "ConnectorViability", connectorViability * scoringSystem.ConnectorViabilityWeight },
+            { "DuplicateRoomPenalty", duplicateRoomPenalty * scoringSystem.DuplicateRoomPenaltyWeight }
         };
 
         return new PlanScore
@@ -53,6 +56,7 @@ public static class ScoringUtil
         lines.Add("  " + FormatComponent(score, "SizeDiversity", "sizeDiversity"));
         lines.Add("  " + FormatComponent(score, "RoomReuse", "roomReuse"));
         lines.Add("  " + FormatComponent(score, "ConnectorViability", "connectorViability"));
+        lines.Add("  " + FormatComponent(score, "DuplicateRoomPenalty", "duplicateRoomPenalty"));
 
         return string.Join(Environment.NewLine, lines);
     }
@@ -224,6 +228,42 @@ public static class ScoringUtil
         }
 
         return totalArea;
+    }
+
+    /// <summary>
+    /// Calculates a penalty score based on how many times each room prefab in the
+    /// plan already appears as a temporary placed reference in other cells of the mod.
+    /// Returns the sum of existing placement counts for all rooms in the plan.
+    /// </summary>
+    public static double CalculateDuplicateRoomPenalty(IReadOnlyList<PlacedRoom> rooms)
+    {
+        if (rooms == null || rooms.Count == 0)
+            return 0;
+
+        var packInKeys = new HashSet<FormKey>();
+        foreach (var room in rooms)
+        {
+            if (room.Prefab?.packin_instance != null)
+                packInKeys.Add(room.Prefab.packin_instance.FormKey);
+        }
+
+        if (packInKeys.Count == 0)
+            return 0;
+
+        var counts = DuplicateRoomTools.CountPackInPlacements(packInKeys);
+
+        double penalty = 0;
+        foreach (var room in rooms)
+        {
+            if (room.Prefab?.packin_instance == null)
+                continue;
+
+            var key = room.Prefab.packin_instance.FormKey;
+            if (counts.TryGetValue(key, out var count))
+                penalty += count;
+        }
+
+        return penalty;
     }
 
     private static double GetRoomFootprintArea(PlacedRoom room)

--- a/Retrograde.Library/Passes/ScoringSystem.cs
+++ b/Retrograde.Library/Passes/ScoringSystem.cs
@@ -12,6 +12,7 @@ public class ScoringSystem
     public double SizeDiversityWeight;      // How important is avoiding chains of tiny rooms
     public double RoomReuseWeight;          // How important is reusing the same prefab multiple times
     public double ConnectorViabilityWeight; // How important is leaving connectors with viable space for the next room
+    public double DuplicateRoomPenaltyWeight; // How important is penalising rooms that already appear in other cells
 
     public int Effort;
 }

--- a/Retrograde.Library/Passes/Topology/BossTopologyPass.cs
+++ b/Retrograde.Library/Passes/Topology/BossTopologyPass.cs
@@ -149,7 +149,8 @@ namespace Retrograde.Passes
                 var planRoomReuse = ScoringUtil.CalculateRoomReuseScore(plannedRooms);
                 var connectorViability = 0; // Boss placement planSizeDiversity
                 const double planArea = 0; // Boss placement ignores area weighting
-                var planScore = ScoringUtil.ScorePlan(state.scoringSystem, roomsPlaced, bridgeablePairs, 0, 0, planArea, planClustering, planSizeDiversity, planRoomReuse, connectorViability);
+                var duplicateRoomPenalty = ScoringUtil.CalculateDuplicateRoomPenalty(plannedRooms);
+                var planScore = ScoringUtil.ScorePlan(state.scoringSystem, roomsPlaced, bridgeablePairs, 0, 0, planArea, planClustering, planSizeDiversity, planRoomReuse, connectorViability, duplicateRoomPenalty);
 
                 // Check if forced prefab was actually placed
                 int missingRequiredPrefabs = 0;

--- a/Retrograde.Library/Passes/Topology/BridgingTopologyPass.cs
+++ b/Retrograde.Library/Passes/Topology/BridgingTopologyPass.cs
@@ -142,7 +142,8 @@ namespace Retrograde.Passes
                 var planSizeDiversity = ScoringUtil.CalculateSmallRoomChainPenalty(context.PlannedRooms);
                 var planRoomReuse = ScoringUtil.CalculateRoomReuseScore(context.PlannedRooms);
                 var connectorViability = ScoringUtil.CalculateConnectorViabilityArea(context.PlannedRooms, context.PlannedOpenConnectors);
-                var planScore = ScoringUtil.ScorePlan(state.scoringSystem, bridgesPlaced, bridgeablePairs, overlapCount, Math.Max(0, newConnectors), planArea, planClustering, planSizeDiversity, planRoomReuse, connectorViability);
+                var duplicateRoomPenalty = ScoringUtil.CalculateDuplicateRoomPenalty(context.PlannedRooms);
+                var planScore = ScoringUtil.ScorePlan(state.scoringSystem, bridgesPlaced, bridgeablePairs, overlapCount, Math.Max(0, newConnectors), planArea, planClustering, planSizeDiversity, planRoomReuse, connectorViability, duplicateRoomPenalty);
 
                 return new PlanOutcome<BridgePlanMeta>
                 {

--- a/Retrograde.Library/Passes/Topology/DistrictTopologyPass.cs
+++ b/Retrograde.Library/Passes/Topology/DistrictTopologyPass.cs
@@ -231,7 +231,8 @@ namespace Retrograde.Passes
                 var planSizeDiversity = ScoringUtil.CalculateSmallRoomChainPenalty(plannedRooms);
                 var planRoomReuse = ScoringUtil.CalculateRoomReuseScore(plannedRooms);
                 var connectorViability = ScoringUtil.CalculateConnectorViabilityArea(plannedRooms, plannedOpenConnectors);
-                var planScore = ScoringUtil.ScorePlan(state.scoringSystem, roomsPlaced, bridgeablePairs, 0, connectorsAddedCount, planArea, planClustering, planSizeDiversity, planRoomReuse, connectorViability);
+                var duplicateRoomPenalty = ScoringUtil.CalculateDuplicateRoomPenalty(plannedRooms);
+                var planScore = ScoringUtil.ScorePlan(state.scoringSystem, roomsPlaced, bridgeablePairs, 0, connectorsAddedCount, planArea, planClustering, planSizeDiversity, planRoomReuse, connectorViability, duplicateRoomPenalty);
                 int missingRequiredPrefabs = requiredPrefabs.Count;
                 double adjustedPlanScore = planScore.Total - (missingRequiredPrefabs > 0 ? 100000 * missingRequiredPrefabs : 0);
 

--- a/Retrograde.Library/Passes/Topology/TrunkTopologyPass.cs
+++ b/Retrograde.Library/Passes/Topology/TrunkTopologyPass.cs
@@ -186,9 +186,10 @@ namespace Retrograde.Passes
                 var planSizeDiversity = ScoringUtil.CalculateSmallRoomChainPenalty(context.PlannedRooms);
                 var planRoomReuse = ScoringUtil.CalculateRoomReuseScore(context.PlannedRooms);
                 var connectorViability = ScoringUtil.CalculateConnectorViabilityArea(context.PlannedRooms, context.PlannedOpenConnectors);
+                var duplicateRoomPenalty = ScoringUtil.CalculateDuplicateRoomPenalty(context.PlannedRooms);
 
                 // Combine into final plan score
-                var planScore = ScoringUtil.ScorePlan(state.scoringSystem, roomsPlaced, bridgeablePairs, 0, connectorsAddedCount, planArea, planClustering, planSizeDiversity, planRoomReuse, connectorViability);
+                var planScore = ScoringUtil.ScorePlan(state.scoringSystem, roomsPlaced, bridgeablePairs, 0, connectorsAddedCount, planArea, planClustering, planSizeDiversity, planRoomReuse, connectorViability, duplicateRoomPenalty);
                 int missingRequiredPrefabs = context.RequiredPrefabs.Count;
                 double adjustedPlanScore = planScore.Total - (missingRequiredPrefabs > 0 ? 100000 * missingRequiredPrefabs : 0);
 

--- a/Retrograde.Library/StationDesigns/HabStation.cs
+++ b/Retrograde.Library/StationDesigns/HabStation.cs
@@ -79,6 +79,7 @@ public class HabStation : IStationDesign
             SizeDiversityWeight = 5.94,
             RoomReuseWeight = -1.19,
             ConnectorViabilityWeight = 0.67,
+            DuplicateRoomPenaltyWeight = -2.0,
             Effort = 100
         };
     }

--- a/Retrograde.Library/StationDesigns/OreStation.cs
+++ b/Retrograde.Library/StationDesigns/OreStation.cs
@@ -79,6 +79,7 @@ public class OreStation : IStationDesign
             SizeDiversityWeight = 16.06,
             RoomReuseWeight = -3.21,
             ConnectorViabilityWeight = 1.73,
+            DuplicateRoomPenaltyWeight = -2.0,
             Effort = 250
         };
     }

--- a/Retrograde.Library/StationDesigns/OreStationWeightHarness.cs
+++ b/Retrograde.Library/StationDesigns/OreStationWeightHarness.cs
@@ -126,6 +126,7 @@ namespace Retrograde.StationDesigns
                 WriteLog($"    SizeDiversityWeight = {best.Weights.SizeDiversityWeight:0.##},");
                 WriteLog($"    RoomReuseWeight = {best.Weights.RoomReuseWeight:0.##},");
                 WriteLog($"    ConnectorViabilityWeight = {best.Weights.ConnectorViabilityWeight:0.##},");
+                WriteLog($"    DuplicateRoomPenaltyWeight = {best.Weights.DuplicateRoomPenaltyWeight:0.##},");
                 WriteLog($"    Effort = {best.Weights.Effort}");
                 WriteLog("};");
 
@@ -196,6 +197,7 @@ namespace Retrograde.StationDesigns
             double sizeDiversity = ScoringUtil.CalculateSmallRoomChainPenalty(rooms);
             double roomReuse = ScoringUtil.CalculateRoomReuseScore(rooms);
             double connectorViability = ScoringUtil.CalculateConnectorViabilityArea(rooms, opens);
+            double duplicateRoomPenalty = ScoringUtil.CalculateDuplicateRoomPenalty(rooms);
 
             return ScoringUtil.ScorePlan(
                 weights,
@@ -207,7 +209,8 @@ namespace Retrograde.StationDesigns
                 clustering,
                 sizeDiversity,
                 roomReuse,
-                connectorViability);
+                connectorViability,
+                duplicateRoomPenalty);
         }
 
         private static ScoringSystem NormalizeWeights(ScoringSystem src, double budget)
@@ -222,7 +225,8 @@ namespace Retrograde.StationDesigns
                 Math.Abs(src.ClusteringWeight) +
                 Math.Abs(src.SizeDiversityWeight) +
                 Math.Abs(src.RoomReuseWeight) +
-                Math.Abs(src.ConnectorViabilityWeight);
+                Math.Abs(src.ConnectorViabilityWeight) +
+                Math.Abs(src.DuplicateRoomPenaltyWeight);
 
             if (total <= 0.0001)
                 return CloneWeights(src);
@@ -241,6 +245,7 @@ namespace Retrograde.StationDesigns
                 SizeDiversityWeight = src.SizeDiversityWeight * scale,
                 RoomReuseWeight = src.RoomReuseWeight * scale,
                 ConnectorViabilityWeight = src.ConnectorViabilityWeight * scale,
+                DuplicateRoomPenaltyWeight = src.DuplicateRoomPenaltyWeight * scale,
                 Effort = src.Effort
             };
         }
@@ -285,6 +290,7 @@ namespace Retrograde.StationDesigns
                 SizeDiversityWeight = src.SizeDiversityWeight,
                 RoomReuseWeight = src.RoomReuseWeight,
                 ConnectorViabilityWeight = src.ConnectorViabilityWeight,
+                DuplicateRoomPenaltyWeight = src.DuplicateRoomPenaltyWeight,
                 Effort = src.Effort
             };
         }

--- a/Retrograde.Library/StationDesigns/WarrenStation.cs
+++ b/Retrograde.Library/StationDesigns/WarrenStation.cs
@@ -82,6 +82,7 @@ public class WarrenStation : IStationDesign
             SizeDiversityWeight = 10.0,
             RoomReuseWeight = -2.0,
             ConnectorViabilityWeight = 3.0,
+            DuplicateRoomPenaltyWeight = -2.0,
             Effort = 300
         };
     }

--- a/Retrograde.Library/Utils/DuplicateRoomTools.cs
+++ b/Retrograde.Library/Utils/DuplicateRoomTools.cs
@@ -1,0 +1,89 @@
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Starfield;
+using System.Collections.Generic;
+
+namespace Retrograde.Utils;
+
+/// <summary>
+/// Counts how many times each room prefab (PackIn) has been placed across
+/// all cells in the current mod.  Used by the scoring system to penalise
+/// rooms that already appear too frequently.
+/// </summary>
+public static class DuplicateRoomTools
+{
+    /// <summary>
+    /// Scans every cell in the target mod and counts temporary placed references
+    /// whose Base matches each provided PackIn FormKey.
+    /// </summary>
+    /// <returns>
+    /// A dictionary mapping PackIn FormKey → number of existing temporary
+    /// placements found across all other cells in the mod.
+    /// </returns>
+    public static Dictionary<FormKey, int> CountPackInPlacements(IEnumerable<FormKey> packInKeys)
+    {
+        var counts = new Dictionary<FormKey, int>();
+        var keysOfInterest = new HashSet<FormKey>();
+
+        foreach (var key in packInKeys)
+        {
+            keysOfInterest.Add(key);
+            if (!counts.ContainsKey(key))
+                counts[key] = 0;
+        }
+
+        if (keysOfInterest.Count == 0)
+            return counts;
+
+        var mod = RetrogradeContext.Current.TargetMod;
+
+        for (int i = 0; i < mod.Cells.Count; i++)
+        {
+            for (int j = 0; j < mod.Cells[i].SubBlocks.Count; j++)
+            {
+                for (int k = 0; k < mod.Cells[i].SubBlocks[j].Cells.Count; k++)
+                {
+                    var cell = mod.Cells[i].SubBlocks[j].Cells[k];
+                    foreach (var placed in cell.Temporary)
+                    {
+                        if (placed is PlacedObject po)
+                        {
+                            var baseKey = po.Base.FormKey;
+                            if (keysOfInterest.Contains(baseKey))
+                                counts[baseKey]++;
+                        }
+                    }
+                }
+            }
+        }
+
+        return counts;
+    }
+
+    /// <summary>
+    /// Counts how many times a single PackIn FormKey appears as a temporary
+    /// placed reference across all cells in the mod.
+    /// </summary>
+    public static int CountPackInPlacement(FormKey packInKey)
+    {
+        int count = 0;
+        var mod = RetrogradeContext.Current.TargetMod;
+
+        for (int i = 0; i < mod.Cells.Count; i++)
+        {
+            for (int j = 0; j < mod.Cells[i].SubBlocks.Count; j++)
+            {
+                for (int k = 0; k < mod.Cells[i].SubBlocks[j].Cells.Count; k++)
+                {
+                    var cell = mod.Cells[i].SubBlocks[j].Cells[k];
+                    foreach (var placed in cell.Temporary)
+                    {
+                        if (placed is PlacedObject po && po.Base.FormKey == packInKey)
+                            count++;
+                    }
+                }
+            }
+        }
+
+        return count;
+    }
+}


### PR DESCRIPTION
Rooms that already appear frequently across other cells in the mod now
receive a negative score during plan evaluation.  This discourages the
generator from repeatedly picking the same prefabs.

- New DuplicateRoomTools utility scans all cells for PackIn placements
- New DuplicateRoomPenaltyWeight on ScoringSystem (default -2.0)
- CalculateDuplicateRoomPenalty added to ScoringUtil
- All topology passes (Trunk, Boss, Bridging, District) pass the penalty
- OreStationWeightHarness updated for normalize/clone/logging

https://claude.ai/code/session_01DYoXJuKToMfuM8Uac7gm4y