### PR TITLE
Add BTD terrain data reader for Starfield/FO76 heightmaps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,14 +79,14 @@ var formKey = new FormKey(ModKey.FromFileName("Starfield.esm"), 0x00000043);
 
 ## BTD Terrain Data
 
-BTD files (`.btd`) store terrain heightmaps for Starfield and Fallout 76. Reader/writer: `Retrograde.Library/Utils/BtdTerrainReader.cs`.
+BTD files (`.btd`) store terrain heightmaps for Starfield and Fallout 76. Reader/writer: `Retrograde.Library/Utils/BtdFile.cs`.
 
-### File Format (Version 6, Starfield)
+### File Format (Version 5/6, Starfield)
 
-- **Header** (40 bytes): magic `BTDB`, version (6), HeightMin/Max (floats, unscaled), ResX/ResY, CellMin/MaxX/Y
-- **LTEX form IDs**: uint32 count + array of land texture form IDs
+- **Header** (40 bytes): magic `BTDB`, version (5 or 6), HeightMin/Max (floats, unscaled), ResX/ResY, CellMin/MaxX/Y
+- **LTEX form IDs**: uint32 count + array of land texture form IDs (typically 6-7 shared across all Starfield BTDs)
 - **Cell height min/max map**: 8 bytes/cell (float min, float max) — stored in **unscaled** coordinates (before 8x Starfield multiplier)
-- **Land texture map**: 32 bytes/cell — 8 texture layer indices (bytes referencing LTEX array), repeated 4x (possibly per-quadrant)
+- **Land texture map**: 32 bytes/cell — 4 quadrant palettes of 8 bytes each (Q0=TL, Q1=TR, Q2=BL, Q3=BR; boundary at vertex 64). Each byte is an LTEX array index
 - **Ground cover** (FO76 only, absent in Starfield): form IDs + 32 bytes/cell map
 - **LOD4 height map**: 128 bytes/cell — 8x8 grid of uint16 (downsampled from 128x128, every 16th sample)
 - **LOD4 land textures**: 128 bytes/cell
@@ -98,22 +98,57 @@ BTD files (`.btd`) store terrain heightmaps for Starfield and Fallout 76. Reader
 
 ### Texture Data
 
-Each LOD0 block contains per-vertex texture data (128x128 uint16) in the second half of the decompressed block. The cell also has a **land texture map** (32 bytes in the metadata) that defines which 8 LTEX layers are available for that cell.
+Each LOD0 block contains per-vertex texture data (128x128 uint16) in the second half of the decompressed block. The cell also has a **land texture map** (32 bytes in the metadata) and **LOD4 land textures** (128 bytes/cell) that influence rendering.
 
-The per-vertex uint16 encoding is not yet fully understood. Observed properties:
-- Values range widely (0–32000+), not simple layer indices
-- Many unique values per cell (hundreds), suggesting blend/weight encoding
-- Values cluster in specific ranges (e.g., 2048–4095 most common in test BTD)
-- Setting all hill vertices to one of the existing values does produce a visible texture change
+**Land texture map (32 bytes/cell):**
+- 4 groups of 8 bytes — per-quadrant palettes mapping layer indices to LTEX form IDs
+- Each byte is an index into the global LTEX form ID array
+- Different groups can have different LTEX mappings, causing visible quadrant-based texture splits
+- **Critical**: neighboring cells' palettes influence rendering at cell borders. To avoid quadrant splits, normalize all 4 groups to be identical via `SetCellLandTexMap` on **ALL cells** (including edge cells)
+- Some entries may reference out-of-bounds LTEX indices (renders as default/wrong texture)
 
-Reading/writing texture data:
+**Per-vertex uint16 encoding (partially understood):**
+- The full uint16 value determines which texture is rendered — it is NOT a simple `layer << 12 | blend` encoding (that theory was disproven: different "layers" with the same sub-value produce identical textures)
+- Value 0x0000 = no texture / transparent
+- The value interacts with the land texture map palette, but the exact mapping is complex
+- **Known working values** (tested on oebb008world.btd, palette `06 05 04 03 02 00 01 00`):
+  - 0x0100 = "Base sandy" texture
+  - 0x3000 = "slightly less sandy" texture
+  - 0x4000 = "clean bright sand" texture
+  - 0x6000 = "Clean orangy sand" texture
+  - 0x0800, 0x1000, 0x2000, 0x7000 = all show "patchy sandy" (same texture despite spanning different `>> 12` ranges)
+  - 0x0E00 = "patchy sandy" variant
+  - 0x0FFF = "Clean orangy sand" (but had quadrant issues before full palette normalization)
+  - Values with the same low 12 bits but different top 4 bits (e.g., all `N*4096+2048`) produce **identical** textures
+
+**LOD4 land textures (128 bytes/cell):**
+- Affects rendering; should be zeroed when painting custom textures to avoid interference
+- Read/write via `GetCellLod4LandTex` / `SetCellLod4LandTex`
+
+**Complete texture painting workflow:**
 ```csharp
+var reader = new BtdFile(path);
+
+// 1. Normalize ALL cells' land texture maps to avoid quadrant splits
+var palette = new byte[32];
+reader.GetCellLandTexMap(palette, centerCellX, centerCellY);
+for (int q = 1; q < 4; q++)
+    Array.Copy(palette, 0, palette, q * 8, 8);
+for (int cy = reader.CellMinY; cy <= reader.CellMaxY; cy++)
+    for (int cx = reader.CellMinX; cx <= reader.CellMaxX; cx++)
+        reader.SetCellLandTexMap(palette, cx, cy);
+
+// 2. Paint per-vertex texture data
 var texBuf = new ushort[128 * 128];
-reader.GetCellTextureData(texBuf, cellX, cellY);
-// Modify texBuf values...
+for (int i = 0; i < texBuf.Length; i++)
+    texBuf[i] = 0x4000; // "clean bright sand"
 reader.SetCellTextureData(texBuf, cellX, cellY);
-// Or single vertex:
-reader.SetTexture(cellX, cellY, vertX, vertY, rawValue);
+
+// 3. Zero LOD4 land textures for modified cells
+reader.SetCellLod4LandTex(new byte[128], cellX, cellY);
+
+// 4. Save
+reader.Save(outputPath, updateMinMax: false);
 ```
 
 Save automatically patches both height and texture data for dirty cells when `_dirtyTextures` has data.
@@ -132,7 +167,9 @@ Save automatically patches both height and texture data for dirty cells when `_d
 
 ### Edge Cells Are Off-Limits
 
-The outermost ring of cells in a BTD connects the map to the rest of the world. **Never modify edge cells.** For an NxN cell grid, only cells `(CellMinX+1..CellMaxX-1, CellMinY+1..CellMaxY-1)` are safe to edit. A 3x3 BTD has only 1 editable cell in the center.
+The outermost ring of cells in a BTD connects the map to the rest of the world. **Never modify edge cells' height or per-vertex texture data.** For an NxN cell grid, only cells `(CellMinX+1..CellMaxX-1, CellMinY+1..CellMaxY-1)` are safe to edit. A 3x3 BTD has only 1 editable cell in the center.
+
+**Exception**: the land texture map (32-byte palette) on edge cells CAN and SHOULD be normalized when painting textures, because neighboring cells' palettes influence rendering at cell borders.
 
 ### Writing BTD Files
 
@@ -156,13 +193,24 @@ Key pitfalls discovered during development:
 
 ```csharp
 // Read height
-var reader = new BtdTerrainReader(path);
+var reader = new BtdFile(path);
 float h = reader.GetHeight(cellX, cellY, vertX, vertY);
 float h2 = reader.SampleHeightAtWorld(worldX, worldY);
 
-// Read texture
+// Read/write land texture map (32 bytes/cell, 4 quadrant palettes)
+var palette = new byte[32];
+reader.GetCellLandTexMap(palette, cellX, cellY);
+reader.SetCellLandTexMap(palette, cellX, cellY);
+
+// Read/write per-vertex texture (128x128 uint16)
 var texBuf = new ushort[128 * 128];
 reader.GetCellTextureData(texBuf, cellX, cellY);
+reader.SetCellTextureData(texBuf, cellX, cellY);
+
+// Read/write LOD4 land textures (128 bytes/cell)
+var lod4Tex = new byte[128];
+reader.GetCellLod4LandTex(lod4Tex, cellX, cellY);
+reader.SetCellLod4LandTex(lod4Tex, cellX, cellY);
 
 // Write height + texture (additive edit, skip metadata updates)
 reader.SetCellHeightMap(heightBuf, cellX, cellY);
@@ -178,12 +226,24 @@ ushort raw = reader.HeightToRaw(worldHeight);
 float world = reader.RawToHeight(raw);
 ```
 
+### Cross-File Findings (5 Starfield BTDs validated)
+
+All BTDs in `Data\terrain\`: oedb508world, oejm008world, oejp008caveworld, oeob008world, oesd008world.
+
+- **All Starfield**, same height range (-500 to 1000, span 1500), same LTEX form IDs (6-7 entries)
+- **Versions**: 4 files v6, 1 file v5 (oejp008caveworld) — both parse identically as Starfield
+- **Quadrant palette differences are normal** in vanilla files (e.g. oesd008world: only 3/16 cells uniform). Confirms palette normalization is necessary when painting
+- **Default palette `[6,5,4,3,2,0,1,0]`** appears in nearly every file
+- **0x0E00** is the most common texture value across 4/5 files
+- **0x7000, 0x4000, 0x3000, 0x6000** all confirmed present across multiple files
+- Cell grids range from 3x3 to 5x5; all have 0 empty LOD0 blocks
+
 ### Test Harnesses
 
 - `gen_btd_test` — automated reader/writer verification (test_btd.bat)
 - `gen_btd_flatten` — adds a cosine hill to the center cell for visual verification (flatten_btd.bat)
-- `gen_btd_info` — dumps file structure, section layout, block stats, height distribution (info_btd.bat)
-- Test BTD: `C:\Program Files (x86)\Steam\steamapps\common\Starfield\Data\terrain\oebb008world.btd`
+- `gen_btd_info` — dumps file structure, section layout, block stats, height distribution (info_btd.bat); pass a directory path to scan all BTD files (info_btd_all.bat)
+- Test BTDs: `C:\Program Files (x86)\Steam\steamapps\common\Starfield\Data\terrain\`
 
 ## Copying PlacedObjects
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,114 @@ var placed = new PlacedObject(gen_quest_main.myMod)
 var formKey = new FormKey(ModKey.FromFileName("Starfield.esm"), 0x00000043);
 ```
 
+## BTD Terrain Data
+
+BTD files (`.btd`) store terrain heightmaps for Starfield and Fallout 76. Reader/writer: `Retrograde.Library/Utils/BtdTerrainReader.cs`.
+
+### File Format (Version 6, Starfield)
+
+- **Header** (40 bytes): magic `BTDB`, version (6), HeightMin/Max (floats, unscaled), ResX/ResY, CellMin/MaxX/Y
+- **LTEX form IDs**: uint32 count + array of land texture form IDs
+- **Cell height min/max map**: 8 bytes/cell (float min, float max) — stored in **unscaled** coordinates (before 8x Starfield multiplier)
+- **Land texture map**: 32 bytes/cell — 8 texture layer indices (bytes referencing LTEX array), repeated 4x (possibly per-quadrant)
+- **Ground cover** (FO76 only, absent in Starfield): form IDs + 32 bytes/cell map
+- **LOD4 height map**: 128 bytes/cell — 8x8 grid of uint16 (downsampled from 128x128, every 16th sample)
+- **LOD4 land textures**: 128 bytes/cell
+- **Vertex color LOD4** (FO76 only, absent in Starfield): 128 bytes/cell
+- **Block tables**: LOD3→LOD2→LOD1→LOD0 order, each entry is 8 bytes (uint32 offset, uint32 compressed size). Starfield has 1 entry/block; FO76 has 2 entries/block for LOD3/2/0
+- **Compressed block data**: zlib-compressed blocks, each LOD0 block = 65536 bytes:
+  - Bytes 0–32767: height data (128x128 uint16)
+  - Bytes 32768–65535: texture data (128x128 uint16)
+
+### Texture Data
+
+Each LOD0 block contains per-vertex texture data (128x128 uint16) in the second half of the decompressed block. The cell also has a **land texture map** (32 bytes in the metadata) that defines which 8 LTEX layers are available for that cell.
+
+The per-vertex uint16 encoding is not yet fully understood. Observed properties:
+- Values range widely (0–32000+), not simple layer indices
+- Many unique values per cell (hundreds), suggesting blend/weight encoding
+- Values cluster in specific ranges (e.g., 2048–4095 most common in test BTD)
+- Setting all hill vertices to one of the existing values does produce a visible texture change
+
+Reading/writing texture data:
+```csharp
+var texBuf = new ushort[128 * 128];
+reader.GetCellTextureData(texBuf, cellX, cellY);
+// Modify texBuf values...
+reader.SetCellTextureData(texBuf, cellX, cellY);
+// Or single vertex:
+reader.SetTexture(cellX, cellY, vertX, vertY, rawValue);
+```
+
+Save automatically patches both height and texture data for dirty cells when `_dirtyTextures` has data.
+
+### Key Concepts
+
+- **Cells**: 128x128 vertices each, 1 cell = 4096 world units, 32 units per vertex
+- **Tiles**: 8x8 groups of cells, the unit of decompression/caching
+- **LOD levels**: LOD0 = 128x128, LOD1 = 64x64, LOD2 = 32x32, LOD3 = 16x16
+- **Height encoding**: uint16 mapped linearly to `[WorldHeightMin, WorldHeightMax]`
+- **Starfield detection**: all 4 cell boundary fields in header are zero; applies 8x height scale to min/max
+- **Starfield cell bounds**: derived from resolution fields: `CellMinX = -(ResX >> 8)`, `CellCountX = ResX >> 7`
+- **Cell min/max metadata uses UNSCALED heights** — when writing, divide by 8 for Starfield files
+- **Compression**: must use `ZLibStream` (not `DeflateStream`) — requires proper zlib header + Adler32 checksum
+- **Typical terrain heights**: the test BTD (oebb008world) has terrain at ~15–84 world units in a -4000 to 8000 range. `HeightToRaw(0)` = 21845
+
+### Edge Cells Are Off-Limits
+
+The outermost ring of cells in a BTD connects the map to the rest of the world. **Never modify edge cells.** For an NxN cell grid, only cells `(CellMinX+1..CellMaxX-1, CellMinY+1..CellMaxY-1)` are safe to edit. A 3x3 BTD has only 1 editable cell in the center.
+
+### Writing BTD Files
+
+The Save method copies the prefix (header + metadata + block tables) as a byte array, rebuilds compressed block data (dirty blocks are decompressed, patched, recompressed; clean blocks copied verbatim), patches block table entries with new offsets/sizes, then writes prefix + block data.
+
+Key pitfalls discovered during development:
+- **MemoryStream.GetBuffer() reallocation**: don't patch a buffer obtained from GetBuffer() then continue writing to the stream — use a separate byte[] for the prefix
+- **Cell min/max must stay in unscaled coordinates** for Starfield (divide RawToHeight values by 8)
+- **LOD4 height map must be updated** for dirty cells or CK may crash
+- **`updateMinMax: false`** parameter on Save skips min/max and LOD4 metadata updates (useful when making small additive edits that stay within the original height range)
+
+### Edge Smoothing
+
+`SmoothDirtyCellEdges(bandWidth)` blends a transition band at borders between dirty and clean cells:
+- Dirty cell side: lerps from original values at the edge toward modified values in the interior
+- Neighbor cell side: propagates the height delta from the dirty edge, fading to zero
+- Reads original data directly from file bytes (bypasses tile cache) to know the "before" state
+- Automatically marks touched neighbor cells as dirty for Save
+
+### Usage
+
+```csharp
+// Read height
+var reader = new BtdTerrainReader(path);
+float h = reader.GetHeight(cellX, cellY, vertX, vertY);
+float h2 = reader.SampleHeightAtWorld(worldX, worldY);
+
+// Read texture
+var texBuf = new ushort[128 * 128];
+reader.GetCellTextureData(texBuf, cellX, cellY);
+
+// Write height + texture (additive edit, skip metadata updates)
+reader.SetCellHeightMap(heightBuf, cellX, cellY);
+reader.SetCellTextureData(texBuf, cellX, cellY);
+reader.SmoothDirtyCellEdges(32); // blend height seams before saving
+reader.Save(outputPath, updateMinMax: false);
+
+// Write (full edit, update all metadata)
+reader.Save(outputPath); // updateMinMax defaults to true
+
+// Conversion
+ushort raw = reader.HeightToRaw(worldHeight);
+float world = reader.RawToHeight(raw);
+```
+
+### Test Harnesses
+
+- `gen_btd_test` — automated reader/writer verification (test_btd.bat)
+- `gen_btd_flatten` — adds a cosine hill to the center cell for visual verification (flatten_btd.bat)
+- `gen_btd_info` — dumps file structure, section layout, block stats, height distribution (info_btd.bat)
+- Test BTD: `C:\Program Files (x86)\Steam\steamapps\common\Starfield\Data\terrain\oebb008world.btd`
+
 ## Copying PlacedObjects
 
 When duplicating a `PlacedObject` from a prefab cell into the world, do NOT use `DeepCopy()` — it preserves the original FormKey, causing ID collisions. Instead, create a `new PlacedObject(RetrogradeContext.Current.TargetMod)` (which assigns a fresh FormKey) and copy all properties manually. See `CellTools.CloneCellById` for the canonical pattern.

--- a/Program.cs
+++ b/Program.cs
@@ -1,7 +1,7 @@
 ﻿using FrankyCLI;
 using System.Windows.Markup;
 
-Console.WriteLine("FrankyCLI. Build new ship part.");
+Console.WriteLine("FrankyCLI");
 
 //Process the args
 for (int i = 0; i < args.Length; i++)
@@ -79,6 +79,15 @@ switch(mode)
 
     case "gen_report":
         res = gen_report.Generate(args);
+        break;
+    case "gen_btd_test":
+        res = gen_btd_test.Generate(args);
+        break;
+    case "gen_btd_flatten":
+        res = gen_btd_flatten.Generate(args);
+        break;
+    case "gen_btd_info":
+        res = gen_btd_info.Generate(args);
         break;
     default:
         Console.WriteLine("No mode provided, valid types are: (struct)");

--- a/Program.cs
+++ b/Program.cs
@@ -89,6 +89,9 @@ switch(mode)
     case "gen_btd_info":
         res = gen_btd_info.Generate(args);
         break;
+    case "gen_btd_flatcircle":
+        res = gen_btd_flatcircle.Generate(args);
+        break;
     default:
         Console.WriteLine("No mode provided, valid types are: (struct)");
         break;

--- a/Retrograde.Library/Utils/BtdFile.cs
+++ b/Retrograde.Library/Utils/BtdFile.cs
@@ -562,6 +562,87 @@ namespace Retrograde.Utils
         }
 
         /// <summary>
+        /// Flattens terrain in an axis-aligned rectangle around a world-space point.
+        /// The target height is sampled from the terrain at the center.
+        /// A smooth blend band around the outer edge transitions from flat back to original terrain.
+        /// Respects edge cell boundaries (won't modify outermost ring of cells).
+        /// </summary>
+        /// <param name="worldX">World-space X of rectangle center.</param>
+        /// <param name="worldY">World-space Y of rectangle center.</param>
+        /// <param name="halfWidth">Half-width of the flat area in world units (X axis).</param>
+        /// <param name="halfHeight">Half-height of the flat area in world units (Y axis).</param>
+        /// <param name="blendWidth">Width of the smooth transition band in world units (default 256 = 8 vertices).</param>
+        /// <returns>The world-space height the area was flattened to.</returns>
+        public float FlattenSquare(float worldX, float worldY, float halfWidth, float halfHeight, float blendWidth = 256f)
+        {
+            const float cellSize = 4096f;
+            const float vertSpacing = 32f;
+
+            float targetHeight = SampleHeightAtWorld(worldX, worldY);
+            ushort targetRaw = HeightToRaw(targetHeight);
+
+            float outerHalfW = halfWidth + blendWidth;
+            float outerHalfH = halfHeight + blendWidth;
+
+            int safeMinX = CellMinX + 1;
+            int safeMaxX = CellMaxX - 1;
+            int safeMinY = CellMinY + 1;
+            int safeMaxY = CellMaxY - 1;
+
+            for (int cy = safeMinY; cy <= safeMaxY; cy++)
+            {
+                for (int cx = safeMinX; cx <= safeMaxX; cx++)
+                {
+                    // Quick AABB reject
+                    float cellWorldMinX = cx * cellSize;
+                    float cellWorldMaxX = cellWorldMinX + 127 * vertSpacing;
+                    float cellWorldMinY = cy * cellSize;
+                    float cellWorldMaxY = cellWorldMinY + 127 * vertSpacing;
+
+                    if (cellWorldMaxX < worldX - outerHalfW || cellWorldMinX > worldX + outerHalfW) continue;
+                    if (cellWorldMaxY < worldY - outerHalfH || cellWorldMinY > worldY + outerHalfH) continue;
+
+                    var buf = new ushort[CellResolution * CellResolution];
+                    GetCellHeightMap(buf, cx, cy, 0);
+                    bool modified = false;
+
+                    for (int vy = 0; vy < CellResolution; vy++)
+                    {
+                        float wy = cy * cellSize + vy * vertSpacing;
+                        for (int vx = 0; vx < CellResolution; vx++)
+                        {
+                            float wx = cx * cellSize + vx * vertSpacing;
+
+                            // Signed distance to the rectangle edge (negative = inside, positive = outside)
+                            float distX = Math.Max(0, Math.Abs(wx - worldX) - halfWidth);
+                            float distY = Math.Max(0, Math.Abs(wy - worldY) - halfHeight);
+                            float dist = MathF.Sqrt(distX * distX + distY * distY);
+
+                            if (dist <= 0f)
+                            {
+                                buf[vy * CellResolution + vx] = targetRaw;
+                                modified = true;
+                            }
+                            else if (dist < blendWidth)
+                            {
+                                float t = dist / blendWidth;
+                                float s = t * t * (3f - 2f * t);
+                                ushort original = buf[vy * CellResolution + vx];
+                                buf[vy * CellResolution + vx] = LerpRaw(targetRaw, original, s);
+                                modified = true;
+                            }
+                        }
+                    }
+
+                    if (modified)
+                        SetCellHeightMap(buf, cx, cy);
+                }
+            }
+
+            return targetHeight;
+        }
+
+        /// <summary>
         /// Smooths the edges of dirty cells where they border unmodified cells.
         /// Creates a linear blend over `bandWidth` vertices at each dirty cell edge
         /// that neighbors a clean cell, eliminating hard seams.

--- a/Retrograde.Library/Utils/BtdFile.cs
+++ b/Retrograde.Library/Utils/BtdFile.cs
@@ -16,7 +16,7 @@ namespace Retrograde.Utils
     /// Starfield BTDs are detected by all cell boundary fields being zero, and apply an 8x
     /// height scale factor.
     /// </summary>
-    public class BtdTerrainReader
+    public class BtdFile
     {
         /// <summary>Vertices per cell edge at full (LOD0) resolution.</summary>
         public const int CellResolution = 128;
@@ -46,7 +46,9 @@ namespace Retrograde.Utils
 
         // Metadata section offsets (needed for Save to update min/max and LOD4)
         private long _cellHeightMinMaxOffs;
+        private long _landTexMapOffs;
         private long _lod4HeightMapOffs;
+        private long _lod4LandTexOffs;
 
         // Tile cache: key = (tileY << 16) | tileX
         private readonly Dictionary<uint, TileData> _tileCache = new Dictionary<uint, TileData>();
@@ -66,11 +68,11 @@ namespace Retrograde.Utils
             public ushort[] HeightMap; // TileStride * TileStride
         }
 
-        public BtdTerrainReader()
+        public BtdFile()
         {
         }
 
-        public BtdTerrainReader(string path)
+        public BtdFile(string path)
         {
             Load(path);
         }
@@ -148,7 +150,8 @@ namespace Retrograde.Utils
             _cellHeightMinMaxOffs = pos;
             pos += (long)CellCountY * CellCountX * 8;
 
-            // Land texture map: 32 bytes per cell
+            // Land texture map: 32 bytes per cell (4 quadrant palettes of 8 bytes each)
+            _landTexMapOffs = pos;
             pos += (long)CellCountY * CellCountX * 32;
 
             // Ground cover (not present in Starfield)
@@ -165,6 +168,7 @@ namespace Retrograde.Utils
             pos += (long)CellCountY * CellCountX * 128;
 
             // LOD4 land textures: 128 bytes per cell
+            _lod4LandTexOffs = pos;
             pos += (long)CellCountY * CellCountX * 128;
 
             // Vertex color LOD4 (not present in Starfield)
@@ -385,6 +389,55 @@ namespace Retrograde.Utils
             _dirtyCells.Add(key);
         }
 
+        /// <summary>
+        /// Reads the 32-byte land texture map for a cell (4 quadrant palettes of 8 LTEX indices each).
+        /// </summary>
+        public void GetCellLandTexMap(byte[] buf32, int cellX, int cellY)
+        {
+            int dx = cellX - CellMinX;
+            int dy = cellY - CellMinY;
+            long off = _landTexMapOffs + ((long)dy * CellCountX + dx) * 32;
+            for (int i = 0; i < 32; i++)
+                buf32[i] = _fileData[off + i];
+        }
+
+        /// <summary>
+        /// Writes the 32-byte land texture map for a cell directly into the file data buffer.
+        /// Call before Save() to update quadrant palettes.
+        /// </summary>
+        public void SetCellLandTexMap(byte[] buf32, int cellX, int cellY)
+        {
+            int dx = cellX - CellMinX;
+            int dy = cellY - CellMinY;
+            long off = _landTexMapOffs + ((long)dy * CellCountX + dx) * 32;
+            for (int i = 0; i < 32; i++)
+                _fileData[off + i] = buf32[i];
+        }
+
+        /// <summary>
+        /// Reads the 128-byte LOD4 land texture data for a cell.
+        /// </summary>
+        public void GetCellLod4LandTex(byte[] buf128, int cellX, int cellY)
+        {
+            int dx = cellX - CellMinX;
+            int dy = cellY - CellMinY;
+            long off = _lod4LandTexOffs + ((long)dy * CellCountX + dx) * 128;
+            for (int i = 0; i < 128; i++)
+                buf128[i] = _fileData[off + i];
+        }
+
+        /// <summary>
+        /// Writes the 128-byte LOD4 land texture data for a cell.
+        /// </summary>
+        public void SetCellLod4LandTex(byte[] buf128, int cellX, int cellY)
+        {
+            int dx = cellX - CellMinX;
+            int dy = cellY - CellMinY;
+            long off = _lod4LandTexOffs + ((long)dy * CellCountX + dx) * 128;
+            for (int i = 0; i < 128; i++)
+                _fileData[off + i] = buf128[i];
+        }
+
         private void GetCellTextureDataFromFile(ushort[] buf, int cellX, int cellY)
         {
             int dx = cellX - CellMinX;
@@ -425,6 +478,87 @@ namespace Retrograde.Utils
             tile.HeightMap[(localY + vertY) * TileStride + localX + vertX] = raw;
 
             _dirtyCells.Add((cellX - CellMinX, cellY - CellMinY));
+        }
+
+        /// <summary>
+        /// Flattens terrain in a circle around a world-space point. The target height is
+        /// sampled from the terrain at the center. A smooth blend band around the outer
+        /// edge transitions from flat back to the original terrain.
+        /// Respects edge cell boundaries (won't modify outermost ring of cells).
+        /// </summary>
+        /// <param name="worldX">World-space X of circle center.</param>
+        /// <param name="worldY">World-space Y of circle center.</param>
+        /// <param name="radius">Radius of the flat area in world units.</param>
+        /// <param name="blendWidth">Width of the smooth transition band in world units (default 256 = 8 vertices).</param>
+        /// <returns>The world-space height the area was flattened to.</returns>
+        public float FlattenCircle(float worldX, float worldY, float radius, float blendWidth = 256f)
+        {
+            const float cellSize = 4096f;
+            const float vertSpacing = 32f; // cellSize / CellResolution
+
+            float targetHeight = SampleHeightAtWorld(worldX, worldY);
+            ushort targetRaw = HeightToRaw(targetHeight);
+            float outerRadius = radius + blendWidth;
+
+            // Safe cell range (skip edge cells)
+            int safeMinX = CellMinX + 1;
+            int safeMaxX = CellMaxX - 1;
+            int safeMinY = CellMinY + 1;
+            int safeMaxY = CellMaxY - 1;
+
+            for (int cy = safeMinY; cy <= safeMaxY; cy++)
+            {
+                for (int cx = safeMinX; cx <= safeMaxX; cx++)
+                {
+                    // Quick AABB reject: does this cell overlap the outer circle?
+                    float cellWorldMinX = cx * cellSize;
+                    float cellWorldMaxX = cellWorldMinX + 127 * vertSpacing;
+                    float cellWorldMinY = cy * cellSize;
+                    float cellWorldMaxY = cellWorldMinY + 127 * vertSpacing;
+
+                    float nearX = Math.Clamp(worldX, cellWorldMinX, cellWorldMaxX);
+                    float nearY = Math.Clamp(worldY, cellWorldMinY, cellWorldMaxY);
+                    float nearDist = MathF.Sqrt((nearX - worldX) * (nearX - worldX) + (nearY - worldY) * (nearY - worldY));
+                    if (nearDist > outerRadius)
+                        continue;
+
+                    var buf = new ushort[CellResolution * CellResolution];
+                    GetCellHeightMap(buf, cx, cy, 0);
+                    bool modified = false;
+
+                    for (int vy = 0; vy < CellResolution; vy++)
+                    {
+                        float wy = cy * cellSize + vy * vertSpacing;
+                        for (int vx = 0; vx < CellResolution; vx++)
+                        {
+                            float wx = cx * cellSize + vx * vertSpacing;
+                            float dx = wx - worldX;
+                            float dy = wy - worldY;
+                            float dist = MathF.Sqrt(dx * dx + dy * dy);
+
+                            if (dist <= radius)
+                            {
+                                buf[vy * CellResolution + vx] = targetRaw;
+                                modified = true;
+                            }
+                            else if (dist < outerRadius)
+                            {
+                                float t = (dist - radius) / blendWidth; // 0 at inner edge, 1 at outer edge
+                                // Smooth hermite interpolation for a nice curve
+                                float s = t * t * (3f - 2f * t);
+                                ushort original = buf[vy * CellResolution + vx];
+                                buf[vy * CellResolution + vx] = LerpRaw(targetRaw, original, s);
+                                modified = true;
+                            }
+                        }
+                    }
+
+                    if (modified)
+                        SetCellHeightMap(buf, cx, cy);
+                }
+            }
+
+            return targetHeight;
         }
 
         /// <summary>

--- a/Retrograde.Library/Utils/BtdTerrainReader.cs
+++ b/Retrograde.Library/Utils/BtdTerrainReader.cs
@@ -1,0 +1,486 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+
+namespace Retrograde.Utils
+{
+    /// <summary>
+    /// Reads Bethesda Terrain Data (.btd) files used by Starfield (and Fallout 76).
+    /// Based on the fo76utils reverse engineering of the BTDB format.
+    ///
+    /// The BTD stores terrain height data organized into cells (128x128 vertices each)
+    /// grouped into 8x8 cell tiles, with multiple LOD levels and zlib compression.
+    ///
+    /// Height values are stored as uint16 and mapped linearly to [worldHeightMin, worldHeightMax].
+    /// Starfield BTDs are detected by all cell boundary fields being zero, and apply an 8x
+    /// height scale factor.
+    /// </summary>
+    public class BtdTerrainReader
+    {
+        /// <summary>Vertices per cell edge at full (LOD0) resolution.</summary>
+        public const int CellResolution = 128;
+
+        /// <summary>Cells per tile edge. Tiles are the unit of cached decompression.</summary>
+        private const int TileSize = 8;
+
+        /// <summary>Tile data stride: TileSize * CellResolution = 1024.</summary>
+        private const int TileStride = TileSize * CellResolution;
+
+        public int CellMinX { get; private set; }
+        public int CellMinY { get; private set; }
+        public int CellMaxX { get; private set; }
+        public int CellMaxY { get; private set; }
+        public int CellCountX { get; private set; }
+        public int CellCountY { get; private set; }
+        public float WorldHeightMin { get; private set; }
+        public float WorldHeightMax { get; private set; }
+        public bool IsStarfield { get; private set; }
+
+        private byte[] _fileData;
+        private long _zlibBlocksDataOffs;
+        private long _zlibBlkTableOffsLOD0;
+        private long _zlibBlkTableOffsLOD1;
+        private long _zlibBlkTableOffsLOD2;
+        private long _zlibBlkTableOffsLOD3;
+
+        // Tile cache: key = (tileY << 16) | tileX
+        private readonly Dictionary<uint, TileData> _tileCache = new Dictionary<uint, TileData>();
+        private int _tileCacheMaxSize = 16;
+
+        private class TileData
+        {
+            public int X0;
+            public int Y0;
+            public ushort[] HeightMap; // TileStride * TileStride
+        }
+
+        public BtdTerrainReader()
+        {
+        }
+
+        public BtdTerrainReader(string path)
+        {
+            Load(path);
+        }
+
+        public void Load(string path)
+        {
+            _fileData = File.ReadAllBytes(path);
+            ParseHeader();
+        }
+
+        public void Load(byte[] data)
+        {
+            _fileData = data;
+            ParseHeader();
+        }
+
+        private void ParseHeader()
+        {
+            if (_fileData.Length < 40)
+                throw new InvalidDataException("File too small to be a BTD file");
+
+            // Magic: "BTDB"
+            if (_fileData[0] != (byte)'B' || _fileData[1] != (byte)'T' ||
+                _fileData[2] != (byte)'D' || _fileData[3] != (byte)'B')
+                throw new InvalidDataException("Not a BTD file (invalid magic)");
+
+            uint version = ReadUInt32(4);
+            if (version != 5 && version != 6)
+                throw new InvalidDataException($"Unsupported BTD version: {version}");
+
+            float heightMin = ReadFloat(0x08);
+            float heightMax = ReadFloat(0x0C);
+            uint resX = ReadUInt32(0x10);
+            uint resY = ReadUInt32(0x14);
+            int cellMinX = ReadInt32(0x18);
+            int cellMinY = ReadInt32(0x1C);
+            int cellMaxX = ReadInt32(0x20);
+            int cellMaxY = ReadInt32(0x24);
+
+            // Starfield BTDs have all cell boundaries zeroed
+            IsStarfield = (cellMinX | cellMinY | cellMaxX | cellMaxY) == 0;
+
+            if (IsStarfield)
+            {
+                heightMin *= 8.0f;
+                heightMax *= 8.0f;
+                cellMinX = -(int)(resX >> 8);
+                cellMinY = -(int)(resY >> 8);
+                cellMaxX = cellMinX + (int)(resX >> 7) - 1;
+                cellMaxY = cellMinY + (int)(resY >> 7) - 1;
+            }
+
+            WorldHeightMin = heightMin;
+            WorldHeightMax = heightMax;
+            CellMinX = cellMinX;
+            CellMinY = cellMinY;
+            CellMaxX = cellMaxX;
+            CellMaxY = cellMaxY;
+            CellCountX = cellMaxX + 1 - cellMinX;
+            CellCountY = cellMaxY + 1 - cellMinY;
+
+            CalculateSectionOffsets();
+        }
+
+        private void CalculateSectionOffsets()
+        {
+            long pos = 0x28; // after 40-byte header
+
+            // Land texture form IDs
+            uint ltexCnt = ReadUInt32(pos);
+            pos += 4;
+            pos += ltexCnt * 4; // skip form ID array
+
+            // Cell height min/max map: 8 bytes per cell
+            pos += (long)CellCountY * CellCountX * 8;
+
+            // Land texture map: 32 bytes per cell
+            pos += (long)CellCountY * CellCountX * 32;
+
+            // Ground cover (not present in Starfield)
+            if (!IsStarfield)
+            {
+                uint gcvrCnt = ReadUInt32(pos);
+                pos += 4;
+                pos += gcvrCnt * 4; // skip form ID array
+                pos += (long)CellCountY * CellCountX * 32; // ground cover map
+            }
+
+            // LOD4 height map: 128 bytes per cell
+            pos += (long)CellCountY * CellCountX * 128;
+
+            // LOD4 land textures: 128 bytes per cell
+            pos += (long)CellCountY * CellCountX * 128;
+
+            // Vertex color LOD4 (not present in Starfield)
+            if (!IsStarfield)
+                pos += (long)CellCountY * CellCountX * 128;
+
+            // Compressed block tables
+            if (IsStarfield)
+            {
+                _zlibBlkTableOffsLOD3 = pos;
+                pos += CeilDiv(CellCountY, 8) * CeilDiv(CellCountX, 8) * 8;
+
+                _zlibBlkTableOffsLOD2 = pos;
+                pos += CeilDiv(CellCountY, 4) * CeilDiv(CellCountX, 4) * 8;
+
+                _zlibBlkTableOffsLOD1 = pos;
+                pos += CeilDiv(CellCountY, 2) * CeilDiv(CellCountX, 2) * 8;
+
+                _zlibBlkTableOffsLOD0 = pos;
+                pos += (long)CellCountY * CellCountX * 8;
+            }
+            else
+            {
+                _zlibBlkTableOffsLOD3 = pos;
+                pos += CeilDiv(CellCountY, 8) * CeilDiv(CellCountX, 8) * 2 * 8;
+
+                _zlibBlkTableOffsLOD2 = pos;
+                pos += CeilDiv(CellCountY, 4) * CeilDiv(CellCountX, 4) * 2 * 8;
+
+                _zlibBlkTableOffsLOD1 = pos;
+                pos += CeilDiv(CellCountY, 2) * CeilDiv(CellCountX, 2) * 8;
+
+                _zlibBlkTableOffsLOD0 = pos;
+                pos += (long)CellCountY * CellCountX * 2 * 8;
+            }
+
+            _zlibBlocksDataOffs = pos;
+        }
+
+        /// <summary>
+        /// Gets the raw uint16 height map for a single cell at the specified LOD level.
+        /// LOD 0 = full resolution (128x128), LOD 1 = 64x64, LOD 2 = 32x32, LOD 3 = 16x16.
+        /// Buffer must be at least (128 >> lod)^2 elements.
+        /// </summary>
+        public void GetCellHeightMap(ushort[] buf, int cellX, int cellY, int lod = 0)
+        {
+            if (cellX < CellMinX || cellX > CellMaxX || cellY < CellMinY || cellY > CellMaxY)
+                throw new ArgumentOutOfRangeException($"Cell ({cellX}, {cellY}) is out of range");
+
+            lod = Math.Clamp(lod, 0, 3);
+            var tile = LoadTile(cellX, cellY, lod);
+
+            int localX = ((cellX - CellMinX) & (TileSize - 1)) * CellResolution;
+            int localY = ((cellY - CellMinY) & (TileSize - 1)) * CellResolution;
+            int n = CellResolution >> lod;
+            int step = 1 << lod;
+
+            for (int vy = 0; vy < n; vy++)
+            {
+                for (int vx = 0; vx < n; vx++)
+                {
+                    int srcIdx = (localY + vy * step) * TileStride + localX + vx * step;
+                    buf[vy * n + vx] = tile.HeightMap[srcIdx];
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the height in world units for a single cell vertex.
+        /// vertX/vertY are 0..127 within the cell at LOD 0.
+        /// </summary>
+        public float GetHeight(int cellX, int cellY, int vertX, int vertY)
+        {
+            var tile = LoadTile(cellX, cellY, 0);
+            int localX = ((cellX - CellMinX) & (TileSize - 1)) * CellResolution;
+            int localY = ((cellY - CellMinY) & (TileSize - 1)) * CellResolution;
+            int idx = (localY + vertY) * TileStride + localX + vertX;
+            return RawToHeight(tile.HeightMap[idx]);
+        }
+
+        /// <summary>
+        /// Samples interpolated world-space height at an arbitrary world X/Y position.
+        /// In Creation Engine, 1 cell = 4096 units, each cell has 128 vertices → 32 units per vertex.
+        /// </summary>
+        public float SampleHeightAtWorld(float worldX, float worldY)
+        {
+            const float cellSize = 4096f;
+
+            float cellFX = worldX / cellSize;
+            float cellFY = worldY / cellSize;
+
+            int cellX = (int)Math.Floor(cellFX);
+            int cellY = (int)Math.Floor(cellFY);
+
+            // Local position within cell in vertex space (0..128)
+            float localVX = (cellFX - cellX) * CellResolution;
+            float localVY = (cellFY - cellY) * CellResolution;
+
+            int vx0 = Math.Clamp((int)localVX, 0, CellResolution - 2);
+            int vy0 = Math.Clamp((int)localVY, 0, CellResolution - 2);
+            int vx1 = vx0 + 1;
+            int vy1 = vy0 + 1;
+            float tx = localVX - vx0;
+            float ty = localVY - vy0;
+
+            // Clamp cell to valid range
+            int cx = Math.Clamp(cellX, CellMinX, CellMaxX);
+            int cy = Math.Clamp(cellY, CellMinY, CellMaxY);
+
+            var tile = LoadTile(cx, cy, 0);
+            int baseX = ((cx - CellMinX) & (TileSize - 1)) * CellResolution;
+            int baseY = ((cy - CellMinY) & (TileSize - 1)) * CellResolution;
+
+            float h00 = RawToHeight(tile.HeightMap[(baseY + vy0) * TileStride + baseX + vx0]);
+            float h10 = RawToHeight(tile.HeightMap[(baseY + vy0) * TileStride + baseX + vx1]);
+            float h01 = RawToHeight(tile.HeightMap[(baseY + vy1) * TileStride + baseX + vx0]);
+            float h11 = RawToHeight(tile.HeightMap[(baseY + vy1) * TileStride + baseX + vx1]);
+
+            // Bilinear interpolation
+            return (h00 * (1 - tx) + h10 * tx) * (1 - ty)
+                 + (h01 * (1 - tx) + h11 * tx) * ty;
+        }
+
+        /// <summary>
+        /// Converts a raw uint16 height value to world-space height.
+        /// </summary>
+        public float RawToHeight(ushort raw)
+        {
+            return WorldHeightMin + (raw / 65535.0f) * (WorldHeightMax - WorldHeightMin);
+        }
+
+        private TileData LoadTile(int cellX, int cellY, int lod)
+        {
+            int tileX = (cellX - CellMinX) & ~(TileSize - 1);
+            int tileY = (cellY - CellMinY) & ~(TileSize - 1);
+            uint cacheKey = (uint)(tileY << 16) | (uint)tileX;
+
+            if (_tileCache.TryGetValue(cacheKey, out var cached))
+                return cached;
+
+            var tile = new TileData
+            {
+                X0 = tileX,
+                Y0 = tileY,
+                HeightMap = new ushort[TileStride * TileStride]
+            };
+
+            if (IsStarfield)
+                LoadBlocksStarfield(tile, tileX, tileY, lod);
+            else
+                LoadBlocksStandard(tile, tileX, tileY, lod);
+
+            // Evict oldest entry if cache is full
+            if (_tileCache.Count >= _tileCacheMaxSize)
+                _tileCache.Clear();
+
+            _tileCache[cacheKey] = tile;
+            return tile;
+        }
+
+        private void LoadBlocksStarfield(TileData tile, int tileX, int tileY, int lod)
+        {
+            int cellsPerBlock = 1 << lod;
+            int blocksPerTile = TileSize >> lod;
+
+            for (int by = 0; by < blocksPerTile; by++)
+            {
+                int cellY = tileY + (by << lod);
+                if (cellY >= CellCountY) break;
+
+                for (int bx = 0; bx < blocksPerTile; bx++)
+                {
+                    int cellX = tileX + (bx << lod);
+                    if (cellX >= CellCountX) break;
+
+                    int gridW = CeilDiv(CellCountX, cellsPerBlock);
+                    int blockIndex = (cellY >> lod) * gridW + (cellX >> lod);
+
+                    long tableOffs = GetLodTableOffset(lod) + blockIndex * 8;
+                    if (tableOffs + 8 > _fileData.Length) continue;
+
+                    uint dataOffset = ReadUInt32(tableOffs);
+                    uint compressedSize = ReadUInt32(tableOffs + 4);
+                    if (compressedSize == 0) continue;
+
+                    long absOffset = _zlibBlocksDataOffs + dataOffset;
+                    if (absOffset + compressedSize > _fileData.Length) continue;
+
+                    byte[] decompressed = DecompressZlib(_fileData, absOffset, compressedSize, 65536);
+                    if (decompressed == null) continue;
+
+                    // First 128*128 uint16 = height data, second 128*128 uint16 = texture data.
+                    // Each decompressed block is 128x128 values written at stride (1 << lod)
+                    // into the tile array, so blocks are spaced by 128 * step in tile coordinates.
+                    int step = 1 << lod;
+                    int destX = bx * CellResolution * step;
+                    int destY = by * CellResolution * step;
+
+                    int srcPos = 0;
+                    for (int vy = 0; vy < CellResolution; vy++)
+                    {
+                        int dstRow = (destY + vy * step) * TileStride + destX;
+                        for (int vx = 0; vx < CellResolution; vx++)
+                        {
+                            ushort val = (ushort)(decompressed[srcPos] | (decompressed[srcPos + 1] << 8));
+                            srcPos += 2;
+                            if (dstRow + vx * step < tile.HeightMap.Length)
+                                tile.HeightMap[dstRow + vx * step] = val;
+                        }
+                    }
+                }
+            }
+        }
+
+        private void LoadBlocksStandard(TileData tile, int tileX, int tileY, int lod)
+        {
+            int cellsPerBlock = 1 << lod;
+            int blocksPerTile = TileSize >> lod;
+
+            for (int by = 0; by < blocksPerTile; by++)
+            {
+                int cellY = tileY + (by << lod);
+                if (cellY >= CellCountY) break;
+
+                for (int bx = 0; bx < blocksPerTile; bx++)
+                {
+                    int cellX = tileX + (bx << lod);
+                    if (cellX >= CellCountX) break;
+
+                    int gridW = CeilDiv(CellCountX, cellsPerBlock);
+                    int blockIndex = (cellY >> lod) * gridW + (cellX >> lod);
+
+                    // Standard format has 2 blocks per entry for LOD3, LOD2, LOD0
+                    int blocksPerEntry = (lod == 1) ? 1 : 2;
+                    long tableOffs = GetLodTableOffset(lod) + blockIndex * blocksPerEntry * 8;
+                    if (tableOffs + 8 > _fileData.Length) continue;
+
+                    uint dataOffset = ReadUInt32(tableOffs);
+                    uint compressedSize = ReadUInt32(tableOffs + 4);
+                    if (compressedSize == 0) continue;
+
+                    long absOffset = _zlibBlocksDataOffs + dataOffset;
+                    if (absOffset + compressedSize > _fileData.Length) continue;
+
+                    // Standard blocks decompress to 49152 bytes (height + texture interleaved)
+                    byte[] decompressed = DecompressZlib(_fileData, absOffset, compressedSize, 49152);
+                    if (decompressed == null) continue;
+
+                    int step = 1 << lod;
+                    int destX = bx * CellResolution * step;
+                    int destY = by * CellResolution * step;
+                    int blockW = lod >= 2 ? 64 : CellResolution;
+                    int blockH = lod >= 2 ? 64 : CellResolution;
+
+                    int srcPos = 0;
+                    for (int vy = 0; vy < blockH; vy++)
+                    {
+                        int dstRow = (destY + vy * step) * TileStride + destX;
+                        for (int vx = 0; vx < blockW; vx++)
+                        {
+                            ushort val = (ushort)(decompressed[srcPos] | (decompressed[srcPos + 1] << 8));
+                            srcPos += 2;
+                            if (dstRow + vx * step < tile.HeightMap.Length)
+                                tile.HeightMap[dstRow + vx * step] = val;
+                        }
+                    }
+                }
+            }
+        }
+
+        private long GetLodTableOffset(int lod)
+        {
+            return lod switch
+            {
+                0 => _zlibBlkTableOffsLOD0,
+                1 => _zlibBlkTableOffsLOD1,
+                2 => _zlibBlkTableOffsLOD2,
+                3 => _zlibBlkTableOffsLOD3,
+                _ => _zlibBlkTableOffsLOD0
+            };
+        }
+
+        private static byte[] DecompressZlib(byte[] data, long offset, uint compressedSize, int expectedSize)
+        {
+            try
+            {
+                // Zlib format: 2-byte header then deflate data
+                // Skip the 2-byte zlib header for DeflateStream
+                if (compressedSize < 3) return null;
+
+                using var ms = new MemoryStream(data, (int)offset + 2, (int)compressedSize - 2);
+                using var deflate = new DeflateStream(ms, CompressionMode.Decompress);
+                var result = new byte[expectedSize];
+                int totalRead = 0;
+                while (totalRead < expectedSize)
+                {
+                    int bytesRead = deflate.Read(result, totalRead, expectedSize - totalRead);
+                    if (bytesRead == 0) break;
+                    totalRead += bytesRead;
+                }
+                return result;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private uint ReadUInt32(long offset)
+        {
+            return (uint)(_fileData[offset]
+                | (_fileData[offset + 1] << 8)
+                | (_fileData[offset + 2] << 16)
+                | (_fileData[offset + 3] << 24));
+        }
+
+        private int ReadInt32(long offset)
+        {
+            return (int)ReadUInt32(offset);
+        }
+
+        private float ReadFloat(long offset)
+        {
+            return BitConverter.ToSingle(_fileData, (int)offset);
+        }
+
+        private static int CeilDiv(int a, int b)
+        {
+            return (a + b - 1) / b;
+        }
+    }
+}

--- a/Retrograde.Library/Utils/BtdTerrainReader.cs
+++ b/Retrograde.Library/Utils/BtdTerrainReader.cs
@@ -44,9 +44,20 @@ namespace Retrograde.Utils
         private long _zlibBlkTableOffsLOD2;
         private long _zlibBlkTableOffsLOD3;
 
+        // Metadata section offsets (needed for Save to update min/max and LOD4)
+        private long _cellHeightMinMaxOffs;
+        private long _lod4HeightMapOffs;
+
         // Tile cache: key = (tileY << 16) | tileX
         private readonly Dictionary<uint, TileData> _tileCache = new Dictionary<uint, TileData>();
         private int _tileCacheMaxSize = 16;
+
+        // Tracks which cells have been modified (cellX - CellMinX, cellY - CellMinY)
+        private readonly HashSet<(int, int)> _dirtyCells = new HashSet<(int, int)>();
+
+        // Per-cell texture data cache (only for cells with texture edits)
+        // Key: (dx, dy) relative to CellMin, Value: 128*128 uint16 texture data
+        private readonly Dictionary<(int, int), ushort[]> _dirtyTextures = new Dictionary<(int, int), ushort[]>();
 
         private class TileData
         {
@@ -134,6 +145,7 @@ namespace Retrograde.Utils
             pos += ltexCnt * 4; // skip form ID array
 
             // Cell height min/max map: 8 bytes per cell
+            _cellHeightMinMaxOffs = pos;
             pos += (long)CellCountY * CellCountX * 8;
 
             // Land texture map: 32 bytes per cell
@@ -149,6 +161,7 @@ namespace Retrograde.Utils
             }
 
             // LOD4 height map: 128 bytes per cell
+            _lod4HeightMapOffs = pos;
             pos += (long)CellCountY * CellCountX * 128;
 
             // LOD4 land textures: 128 bytes per cell
@@ -281,6 +294,488 @@ namespace Retrograde.Utils
         public float RawToHeight(ushort raw)
         {
             return WorldHeightMin + (raw / 65535.0f) * (WorldHeightMax - WorldHeightMin);
+        }
+
+        /// <summary>
+        /// Converts a world-space height to a raw uint16 value. Inverse of RawToHeight.
+        /// </summary>
+        public ushort HeightToRaw(float worldHeight)
+        {
+            float t = (worldHeight - WorldHeightMin) / (WorldHeightMax - WorldHeightMin);
+            return (ushort)Math.Clamp((int)(t * 65535.0f + 0.5f), 0, 65535);
+        }
+
+        /// <summary>
+        /// Sets the raw uint16 height map for a single cell at LOD0.
+        /// Buffer must be exactly 128x128 elements.
+        /// </summary>
+        public void SetCellHeightMap(ushort[] buf, int cellX, int cellY)
+        {
+            if (cellX < CellMinX || cellX > CellMaxX || cellY < CellMinY || cellY > CellMaxY)
+                throw new ArgumentOutOfRangeException($"Cell ({cellX}, {cellY}) is out of range");
+
+            var tile = LoadTile(cellX, cellY, 0);
+            int localX = ((cellX - CellMinX) & (TileSize - 1)) * CellResolution;
+            int localY = ((cellY - CellMinY) & (TileSize - 1)) * CellResolution;
+
+            for (int vy = 0; vy < CellResolution; vy++)
+            {
+                int dstRow = (localY + vy) * TileStride + localX;
+                for (int vx = 0; vx < CellResolution; vx++)
+                    tile.HeightMap[dstRow + vx] = buf[vy * CellResolution + vx];
+            }
+
+            _dirtyCells.Add((cellX - CellMinX, cellY - CellMinY));
+        }
+
+        /// <summary>
+        /// Gets the raw uint16 texture data for a single cell at LOD0 (from the compressed block).
+        /// Buffer must be at least 128*128 elements.
+        /// </summary>
+        public void GetCellTextureData(ushort[] buf, int cellX, int cellY)
+        {
+            if (cellX < CellMinX || cellX > CellMaxX || cellY < CellMinY || cellY > CellMaxY)
+                throw new ArgumentOutOfRangeException($"Cell ({cellX}, {cellY}) is out of range");
+
+            var key = (cellX - CellMinX, cellY - CellMinY);
+            if (_dirtyTextures.TryGetValue(key, out var cached))
+            {
+                Array.Copy(cached, buf, CellResolution * CellResolution);
+                return;
+            }
+
+            // Read from original file
+            var fileBuf = new ushort[CellResolution * CellResolution];
+            GetCellTextureDataFromFile(fileBuf, cellX, cellY);
+            Array.Copy(fileBuf, buf, fileBuf.Length);
+        }
+
+        /// <summary>
+        /// Sets the raw uint16 texture data for a single cell at LOD0.
+        /// Buffer must be exactly 128*128 elements.
+        /// </summary>
+        public void SetCellTextureData(ushort[] buf, int cellX, int cellY)
+        {
+            if (cellX < CellMinX || cellX > CellMaxX || cellY < CellMinY || cellY > CellMaxY)
+                throw new ArgumentOutOfRangeException($"Cell ({cellX}, {cellY}) is out of range");
+
+            var key = (cellX - CellMinX, cellY - CellMinY);
+            var copy = new ushort[CellResolution * CellResolution];
+            Array.Copy(buf, copy, copy.Length);
+            _dirtyTextures[key] = copy;
+            _dirtyCells.Add(key);
+        }
+
+        /// <summary>
+        /// Sets a single vertex texture value as raw uint16 at LOD0.
+        /// </summary>
+        public void SetTexture(int cellX, int cellY, int vertX, int vertY, ushort raw)
+        {
+            if (cellX < CellMinX || cellX > CellMaxX || cellY < CellMinY || cellY > CellMaxY)
+                throw new ArgumentOutOfRangeException($"Cell ({cellX}, {cellY}) is out of range");
+
+            var key = (cellX - CellMinX, cellY - CellMinY);
+            if (!_dirtyTextures.TryGetValue(key, out var tex))
+            {
+                tex = new ushort[CellResolution * CellResolution];
+                GetCellTextureDataFromFile(tex, cellX, cellY);
+                _dirtyTextures[key] = tex;
+            }
+            tex[vertY * CellResolution + vertX] = raw;
+            _dirtyCells.Add(key);
+        }
+
+        private void GetCellTextureDataFromFile(ushort[] buf, int cellX, int cellY)
+        {
+            int dx = cellX - CellMinX;
+            int dy = cellY - CellMinY;
+
+            int gridW = CellCountX;
+            int blockIndex = dy * gridW + dx;
+            long tableOffs = _zlibBlkTableOffsLOD0 + blockIndex * 8;
+            uint dataOffset = ReadUInt32(tableOffs);
+            uint compressedSize = ReadUInt32(tableOffs + 4);
+            if (compressedSize == 0) { Array.Clear(buf, 0, buf.Length); return; }
+
+            long absOffset = _zlibBlocksDataOffs + dataOffset;
+            byte[] decompressed = DecompressZlib(_fileData, absOffset, compressedSize, 65536);
+            if (decompressed == null) { Array.Clear(buf, 0, buf.Length); return; }
+
+            // Texture data starts at byte 32768 (after 128*128 uint16 height data)
+            int texOffset = CellResolution * CellResolution * 2;
+            for (int i = 0; i < CellResolution * CellResolution; i++)
+            {
+                int off = texOffset + i * 2;
+                buf[i] = (ushort)(decompressed[off] | (decompressed[off + 1] << 8));
+            }
+        }
+
+        /// <summary>
+        /// Sets a single vertex height as raw uint16 at LOD0.
+        /// vertX/vertY are 0..127 within the cell.
+        /// </summary>
+        public void SetHeight(int cellX, int cellY, int vertX, int vertY, ushort raw)
+        {
+            if (cellX < CellMinX || cellX > CellMaxX || cellY < CellMinY || cellY > CellMaxY)
+                throw new ArgumentOutOfRangeException($"Cell ({cellX}, {cellY}) is out of range");
+
+            var tile = LoadTile(cellX, cellY, 0);
+            int localX = ((cellX - CellMinX) & (TileSize - 1)) * CellResolution;
+            int localY = ((cellY - CellMinY) & (TileSize - 1)) * CellResolution;
+            tile.HeightMap[(localY + vertY) * TileStride + localX + vertX] = raw;
+
+            _dirtyCells.Add((cellX - CellMinX, cellY - CellMinY));
+        }
+
+        /// <summary>
+        /// Smooths the edges of dirty cells where they border unmodified cells.
+        /// Creates a linear blend over `bandWidth` vertices at each dirty cell edge
+        /// that neighbors a clean cell, eliminating hard seams.
+        /// Call this before Save().
+        /// </summary>
+        public void SmoothDirtyCellEdges(int bandWidth = 16)
+        {
+            // Snapshot the dirty set — we'll mark neighbor cells dirty as we blend into them
+            var originalDirty = new HashSet<(int, int)>(_dirtyCells);
+
+            foreach (var (dx, dy) in originalDirty)
+            {
+                int cellX = dx + CellMinX;
+                int cellY = dy + CellMinY;
+
+                // Check each of the 4 neighbors
+                BlendEdge(cellX, cellY, dx, dy, -1, 0, bandWidth, originalDirty); // left
+                BlendEdge(cellX, cellY, dx, dy, 1, 0, bandWidth, originalDirty);  // right
+                BlendEdge(cellX, cellY, dx, dy, 0, -1, bandWidth, originalDirty); // bottom
+                BlendEdge(cellX, cellY, dx, dy, 0, 1, bandWidth, originalDirty);  // top
+            }
+        }
+
+        private void BlendEdge(int cellX, int cellY, int dx, int dy,
+            int dirX, int dirY, int bandWidth, HashSet<(int, int)> originalDirty)
+        {
+            int nx = dx + dirX;
+            int ny = dy + dirY;
+
+            // Skip if neighbor is out of bounds or also dirty
+            if (nx < 0 || nx >= CellCountX || ny < 0 || ny >= CellCountY) return;
+            if (originalDirty.Contains((nx, ny))) return;
+
+            int neighborCellX = nx + CellMinX;
+            int neighborCellY = ny + CellMinY;
+
+            // Load both tiles
+            var dirtyTile = LoadTile(cellX, cellY, 0);
+            int dirtyLocalX = ((cellX - CellMinX) & (TileSize - 1)) * CellResolution;
+            int dirtyLocalY = ((cellY - CellMinY) & (TileSize - 1)) * CellResolution;
+
+            var cleanTile = LoadTile(neighborCellX, neighborCellY, 0);
+            int cleanLocalX = ((neighborCellX - CellMinX) & (TileSize - 1)) * CellResolution;
+            int cleanLocalY = ((neighborCellY - CellMinY) & (TileSize - 1)) * CellResolution;
+
+            // Read original (unmodified) neighbor edge values for reference
+            var neighborBuf = new ushort[CellResolution * CellResolution];
+            GetCellHeightMapFromFile(neighborBuf, neighborCellX, neighborCellY);
+
+            // Also read original dirty cell values for the edge
+            var dirtyOrigBuf = new ushort[CellResolution * CellResolution];
+            GetCellHeightMapFromFile(dirtyOrigBuf, cellX, cellY);
+
+            int bw = Math.Min(bandWidth, CellResolution / 2);
+
+            if (dirX != 0) // horizontal edge (left/right)
+            {
+                // Blend inside the dirty cell near the edge, and inside the neighbor cell near the edge
+                for (int vy = 0; vy < CellResolution; vy++)
+                {
+                    for (int i = 0; i < bw; i++)
+                    {
+                        float t = (i + 1) / (float)(bw + 1); // 0..1 from edge toward interior
+
+                        // Dirty cell side: blend from edge (t=0 → use original) to interior (t=1 → use modified)
+                        int dvx = dirX > 0 ? (CellResolution - 1 - i) : i;
+                        int dirtyIdx = (dirtyLocalY + vy) * TileStride + dirtyLocalX + dvx;
+                        ushort modifiedVal = dirtyTile.HeightMap[dirtyIdx];
+                        ushort originalVal = dirtyOrigBuf[vy * CellResolution + dvx];
+                        dirtyTile.HeightMap[dirtyIdx] = LerpRaw(originalVal, modifiedVal, t);
+
+                        // Neighbor cell side: blend from interior (t=0 → keep original) to edge (t=1 → approach modified)
+                        int nvx = dirX > 0 ? i : (CellResolution - 1 - i);
+                        int cleanIdx = (cleanLocalY + vy) * TileStride + cleanLocalX + nvx;
+                        ushort neighborVal = neighborBuf[vy * CellResolution + nvx];
+
+                        // Get the modified value at the dirty cell's edge for the target
+                        int edgeVx = dirX > 0 ? (CellResolution - 1) : 0;
+                        ushort edgeModified = dirtyTile.HeightMap[(dirtyLocalY + vy) * TileStride + dirtyLocalX + edgeVx];
+                        ushort edgeOriginal = dirtyOrigBuf[vy * CellResolution + edgeVx];
+                        ushort delta = (ushort)Math.Abs(edgeModified - edgeOriginal);
+                        float neighborT = 1f - t; // strongest near edge, fades toward interior
+                        float blend = neighborT * (edgeModified >= edgeOriginal ? delta : -delta) / 65535f;
+                        float nHeight = RawToHeight(neighborVal) + blend * (WorldHeightMax - WorldHeightMin);
+                        cleanTile.HeightMap[cleanIdx] = HeightToRaw(nHeight);
+                    }
+                }
+                _dirtyCells.Add((nx, ny));
+            }
+            else // vertical edge (top/bottom)
+            {
+                for (int vx = 0; vx < CellResolution; vx++)
+                {
+                    for (int i = 0; i < bw; i++)
+                    {
+                        float t = (i + 1) / (float)(bw + 1);
+
+                        int dvy = dirY > 0 ? (CellResolution - 1 - i) : i;
+                        int dirtyIdx = (dirtyLocalY + dvy) * TileStride + dirtyLocalX + vx;
+                        ushort modifiedVal = dirtyTile.HeightMap[dirtyIdx];
+                        ushort originalVal = dirtyOrigBuf[dvy * CellResolution + vx];
+                        dirtyTile.HeightMap[dirtyIdx] = LerpRaw(originalVal, modifiedVal, t);
+
+                        int nvy = dirY > 0 ? i : (CellResolution - 1 - i);
+                        int cleanIdx = (cleanLocalY + nvy) * TileStride + cleanLocalX + vx;
+                        ushort neighborVal = neighborBuf[nvy * CellResolution + vx];
+
+                        int edgeVy = dirY > 0 ? (CellResolution - 1) : 0;
+                        ushort edgeModified = dirtyTile.HeightMap[(dirtyLocalY + edgeVy) * TileStride + dirtyLocalX + vx];
+                        ushort edgeOriginal = dirtyOrigBuf[edgeVy * CellResolution + vx];
+                        ushort delta = (ushort)Math.Abs(edgeModified - edgeOriginal);
+                        float neighborT = 1f - t;
+                        float blend = neighborT * (edgeModified >= edgeOriginal ? delta : -delta) / 65535f;
+                        float nHeight = RawToHeight(neighborVal) + blend * (WorldHeightMax - WorldHeightMin);
+                        cleanTile.HeightMap[cleanIdx] = HeightToRaw(nHeight);
+                    }
+                }
+                _dirtyCells.Add((nx, ny));
+            }
+        }
+
+        private static ushort LerpRaw(ushort a, ushort b, float t)
+        {
+            return (ushort)Math.Clamp((int)(a + (b - a) * t + 0.5f), 0, 65535);
+        }
+
+        /// <summary>
+        /// Reads a cell's height map directly from the original file data (ignoring tile cache modifications).
+        /// </summary>
+        private void GetCellHeightMapFromFile(ushort[] buf, int cellX, int cellY)
+        {
+            int dx = cellX - CellMinX;
+            int dy = cellY - CellMinY;
+
+            if (!IsStarfield)
+            {
+                // Fall back to reading from tile cache for non-Starfield
+                GetCellHeightMap(buf, cellX, cellY, 0);
+                return;
+            }
+
+            int gridW = CellCountX;
+            int blockIndex = dy * gridW + dx;
+            long tableOffs = _zlibBlkTableOffsLOD0 + blockIndex * 8;
+            uint dataOffset = ReadUInt32(tableOffs);
+            uint compressedSize = ReadUInt32(tableOffs + 4);
+            if (compressedSize == 0) { Array.Clear(buf, 0, buf.Length); return; }
+
+            long absOffset = _zlibBlocksDataOffs + dataOffset;
+            byte[] decompressed = DecompressZlib(_fileData, absOffset, compressedSize, 65536);
+            if (decompressed == null) { Array.Clear(buf, 0, buf.Length); return; }
+
+            for (int i = 0; i < CellResolution * CellResolution; i++)
+            {
+                int off = i * 2;
+                buf[i] = (ushort)(decompressed[off] | (decompressed[off + 1] << 8));
+            }
+        }
+
+        /// <summary>
+        /// Saves the BTD to a new file. Modified cells are recompressed; unmodified blocks
+        /// are copied verbatim. Currently only supports Starfield format.
+        /// </summary>
+        public void Save(string outputPath, bool updateMinMax = true)
+        {
+            if (!IsStarfield)
+                throw new NotSupportedException("Save is currently only supported for Starfield BTD files");
+
+            // Copy the prefix (header + metadata + block tables) into a byte array we can patch
+            var prefix = new byte[_zlibBlocksDataOffs];
+            Array.Copy(_fileData, 0, prefix, 0, prefix.Length);
+
+            // Update cell height min/max and LOD4 height map for dirty cells
+            if (updateMinMax)
+            {
+                foreach (var (dx, dy) in _dirtyCells)
+                {
+                    int cellX = dx + CellMinX;
+                    int cellY = dy + CellMinY;
+                    var tile = LoadTile(cellX, cellY, 0);
+                    int localX = ((cellX - CellMinX) & (TileSize - 1)) * CellResolution;
+                    int localY = ((cellY - CellMinY) & (TileSize - 1)) * CellResolution;
+
+                    // Scan for min/max raw height in this cell
+                    ushort cellMin = ushort.MaxValue;
+                    ushort cellMax = ushort.MinValue;
+                    for (int vy = 0; vy < CellResolution; vy++)
+                    {
+                        int row = (localY + vy) * TileStride + localX;
+                        for (int vx = 0; vx < CellResolution; vx++)
+                        {
+                            ushort val = tile.HeightMap[row + vx];
+                            if (val < cellMin) cellMin = val;
+                            if (val > cellMax) cellMax = val;
+                        }
+                    }
+
+                    // Cell height min/max: stored as float pairs in UNSCALED coordinates
+                    // (before Starfield 8x multiplier), row-major (y * countX + x)
+                    long minMaxOffs = _cellHeightMinMaxOffs + ((long)dy * CellCountX + dx) * 8;
+                    float fMin = RawToHeight(cellMin);
+                    float fMax = RawToHeight(cellMax);
+                    if (IsStarfield) { fMin /= 8f; fMax /= 8f; }
+                    Array.Copy(BitConverter.GetBytes(fMin), 0, prefix, minMaxOffs, 4);
+                    Array.Copy(BitConverter.GetBytes(fMax), 0, prefix, minMaxOffs + 4, 4);
+
+                    // LOD4 height map: 128 bytes per cell = 8x8 grid of uint16 values (64 values = 128 bytes)
+                    // Downsample from 128x128 to 8x8 by taking every 16th sample
+                    long lod4Offs = _lod4HeightMapOffs + ((long)dy * CellCountX + dx) * 128;
+                    for (int ly = 0; ly < 8; ly++)
+                    {
+                        int srcRow = (localY + ly * 16) * TileStride + localX;
+                        for (int lx = 0; lx < 8; lx++)
+                        {
+                            ushort val = tile.HeightMap[srcRow + lx * 16];
+                            prefix[lod4Offs] = (byte)(val & 0xFF);
+                            prefix[lod4Offs + 1] = (byte)(val >> 8);
+                            lod4Offs += 2;
+                        }
+                    }
+                }
+            }
+
+            // Build compressed block data into a separate stream, collect table patches
+            using var blockData = new MemoryStream();
+            uint newDataOffset = 0;
+
+            for (int lod = 3; lod >= 0; lod--)
+            {
+                int cellsPerBlock = 1 << lod;
+                int gridW = CeilDiv(CellCountX, cellsPerBlock);
+                int gridH = CeilDiv(CellCountY, cellsPerBlock);
+                long tableBase = GetLodTableOffset(lod);
+
+                for (int gy = 0; gy < gridH; gy++)
+                {
+                    for (int gx = 0; gx < gridW; gx++)
+                    {
+                        int blockIndex = gy * gridW + gx;
+                        long tableOffs = tableBase + blockIndex * 8;
+
+                        uint origDataOffset = ReadUInt32(tableOffs);
+                        uint origCompressedSize = ReadUInt32(tableOffs + 4);
+
+                        if (origCompressedSize == 0)
+                        {
+                            WriteUInt32InArray(prefix, tableOffs, 0);
+                            WriteUInt32InArray(prefix, tableOffs + 4, 0);
+                            continue;
+                        }
+
+                        // Check if any cell in this block is dirty (LOD0: 1 cell per block)
+                        bool isDirty = false;
+                        if (lod == 0)
+                        {
+                            isDirty = _dirtyCells.Contains((gx, gy));
+                        }
+                        else
+                        {
+                            for (int dy = 0; dy < cellsPerBlock && !isDirty; dy++)
+                                for (int dx = 0; dx < cellsPerBlock && !isDirty; dx++)
+                                    isDirty = _dirtyCells.Contains((gx * cellsPerBlock + dx, gy * cellsPerBlock + dy));
+                        }
+
+                        byte[] compressedBlock;
+                        if (isDirty && lod == 0)
+                        {
+                            // Decompress original to get texture data, patch height data, recompress
+                            long absOffset = _zlibBlocksDataOffs + origDataOffset;
+                            byte[] decompressed = DecompressZlib(_fileData, absOffset, origCompressedSize, 65536);
+                            if (decompressed == null)
+                                decompressed = new byte[65536];
+
+                            // Patch height data from tile cache (first 128*128 uint16)
+                            int cellX = gx + CellMinX;
+                            int cellY = gy + CellMinY;
+                            var tile = LoadTile(cellX, cellY, 0);
+                            int localX = ((cellX - CellMinX) & (TileSize - 1)) * CellResolution;
+                            int localY = ((cellY - CellMinY) & (TileSize - 1)) * CellResolution;
+
+                            int pos = 0;
+                            for (int vy = 0; vy < CellResolution; vy++)
+                            {
+                                int srcRow = (localY + vy) * TileStride + localX;
+                                for (int vx = 0; vx < CellResolution; vx++)
+                                {
+                                    ushort val = tile.HeightMap[srcRow + vx];
+                                    decompressed[pos] = (byte)(val & 0xFF);
+                                    decompressed[pos + 1] = (byte)(val >> 8);
+                                    pos += 2;
+                                }
+                            }
+
+                            // Patch texture data if modified (second 128*128 uint16)
+                            if (_dirtyTextures.TryGetValue((gx, gy), out var texData))
+                            {
+                                int texPos = CellResolution * CellResolution * 2; // 32768
+                                for (int i = 0; i < CellResolution * CellResolution; i++)
+                                {
+                                    decompressed[texPos] = (byte)(texData[i] & 0xFF);
+                                    decompressed[texPos + 1] = (byte)(texData[i] >> 8);
+                                    texPos += 2;
+                                }
+                            }
+
+                            compressedBlock = CompressZlib(decompressed);
+                        }
+                        else
+                        {
+                            // Copy original compressed bytes verbatim
+                            long absOffset = _zlibBlocksDataOffs + origDataOffset;
+                            compressedBlock = new byte[origCompressedSize];
+                            Array.Copy(_fileData, absOffset, compressedBlock, 0, origCompressedSize);
+                        }
+
+                        // Patch block table entry in prefix
+                        WriteUInt32InArray(prefix, tableOffs, newDataOffset);
+                        WriteUInt32InArray(prefix, tableOffs + 4, (uint)compressedBlock.Length);
+
+                        // Append compressed block
+                        blockData.Write(compressedBlock, 0, compressedBlock.Length);
+                        newDataOffset += (uint)compressedBlock.Length;
+                    }
+                }
+            }
+
+            // Write prefix + block data
+            using var fs = new FileStream(outputPath, FileMode.Create, FileAccess.Write);
+            fs.Write(prefix, 0, prefix.Length);
+            blockData.WriteTo(fs);
+        }
+
+        private static byte[] CompressZlib(byte[] data)
+        {
+            using var ms = new MemoryStream();
+            using (var zlib = new ZLibStream(ms, CompressionLevel.Optimal, leaveOpen: true))
+            {
+                zlib.Write(data, 0, data.Length);
+            }
+            return ms.ToArray();
+        }
+
+        private static void WriteUInt32InArray(byte[] buf, long offset, uint value)
+        {
+            buf[offset] = (byte)(value & 0xFF);
+            buf[offset + 1] = (byte)((value >> 8) & 0xFF);
+            buf[offset + 2] = (byte)((value >> 16) & 0xFF);
+            buf[offset + 3] = (byte)((value >> 24) & 0xFF);
         }
 
         private TileData LoadTile(int cellX, int cellY, int lod)
@@ -438,17 +933,15 @@ namespace Retrograde.Utils
         {
             try
             {
-                // Zlib format: 2-byte header then deflate data
-                // Skip the 2-byte zlib header for DeflateStream
                 if (compressedSize < 3) return null;
 
-                using var ms = new MemoryStream(data, (int)offset + 2, (int)compressedSize - 2);
-                using var deflate = new DeflateStream(ms, CompressionMode.Decompress);
+                using var ms = new MemoryStream(data, (int)offset, (int)compressedSize);
+                using var zlib = new ZLibStream(ms, CompressionMode.Decompress);
                 var result = new byte[expectedSize];
                 int totalRead = 0;
                 while (totalRead < expectedSize)
                 {
-                    int bytesRead = deflate.Read(result, totalRead, expectedSize - totalRead);
+                    int bytesRead = zlib.Read(result, totalRead, expectedSize - totalRead);
                     if (bytesRead == 0) break;
                     totalRead += bytesRead;
                 }

--- a/flatcircle_btd.bat
+++ b/flatcircle_btd.bat
@@ -1,0 +1,3 @@
+@echo off
+C:\Git\FrankyCLI\bin\Debug\net6.0\FrankyCLI.exe dummy gen_btd_flatcircle dummy dummy dummy
+pause

--- a/flatten_btd.bat
+++ b/flatten_btd.bat
@@ -1,0 +1,3 @@
+@echo off
+C:\Git\FrankyCLI\bin\Debug\net6.0\FrankyCLI.exe dummy gen_btd_flatten dummy dummy dummy
+pause

--- a/gen_btd_flatcircle.cs
+++ b/gen_btd_flatcircle.cs
@@ -1,0 +1,98 @@
+using Retrograde.Utils;
+using System;
+
+namespace FrankyCLI
+{
+    public class gen_btd_flatcircle
+    {
+        public static int Generate(string[] args)
+        {
+            string btdPath = @"C:\Program Files (x86)\Steam\steamapps\common\Starfield\Data\terrain\oebb008world.btd";
+
+            if (args.Length >= 6 && !string.IsNullOrWhiteSpace(args[5]))
+                btdPath = args[5];
+
+            Console.WriteLine($"=== BTD FlattenCircle Test ===");
+            Console.WriteLine($"File: {btdPath}");
+
+            if (!System.IO.File.Exists(btdPath))
+            {
+                Console.WriteLine($"ERROR: BTD file not found at '{btdPath}'");
+                return 1;
+            }
+
+            var btd = new BtdFile(btdPath);
+            Console.WriteLine($"  Cells: {btd.CellCountX}x{btd.CellCountY} ({btd.CellMinX},{btd.CellMinY}) to ({btd.CellMaxX},{btd.CellMaxY})");
+            Console.WriteLine($"  Height range: {btd.WorldHeightMin} to {btd.WorldHeightMax}");
+
+            // Center of the map in world space
+            float centerCellX = (btd.CellMinX + btd.CellMaxX) / 2.0f;
+            float centerCellY = (btd.CellMinY + btd.CellMaxY) / 2.0f;
+            float worldCenterX = centerCellX * 4096f + 2048f;
+            float worldCenterY = centerCellY * 4096f + 2048f;
+
+            float blendWidth = 256f;
+
+            // --- FlattenCircle test ---
+            float circleRadius = 512f;
+            Console.WriteLine($"\n  --- FlattenCircle ---");
+            Console.WriteLine($"  Center: ({worldCenterX:F0}, {worldCenterY:F0})");
+            Console.WriteLine($"  Radius: {circleRadius} units ({circleRadius / 32f:F0} verts), blend: {blendWidth} units ({blendWidth / 32f:F0} verts)");
+
+            float heightBefore = btd.SampleHeightAtWorld(worldCenterX, worldCenterY);
+            Console.WriteLine($"  Height at center before: {heightBefore:F2}");
+
+            float flatHeight = btd.FlattenCircle(worldCenterX, worldCenterY, circleRadius, blendWidth);
+            Console.WriteLine($"  Flattened to: {flatHeight:F2}");
+
+            Console.WriteLine($"  Circle samples (X axis):");
+            float[] offsets = { 0, 64, 128, 256, 384, 512, 600, 768 };
+            foreach (float off in offsets)
+            {
+                float h = btd.SampleHeightAtWorld(worldCenterX + off, worldCenterY);
+                string zone = off <= circleRadius ? "FLAT" : off <= circleRadius + blendWidth ? "BLEND" : "ORIGINAL";
+                Console.WriteLine($"    +{off,4:F0} units: {h,8:F2}  ({zone})");
+            }
+
+            // --- FlattenSquare test (offset so it doesn't overlap the circle) ---
+            float sqCenterX = worldCenterX - 2048f;
+            float sqCenterY = worldCenterY;
+            float halfW = 384f;
+            float halfH = 256f;
+            Console.WriteLine($"\n  --- FlattenSquare ---");
+            Console.WriteLine($"  Center: ({sqCenterX:F0}, {sqCenterY:F0})");
+            Console.WriteLine($"  Half-size: {halfW}x{halfH} units, blend: {blendWidth} units");
+
+            float sqHeightBefore = btd.SampleHeightAtWorld(sqCenterX, sqCenterY);
+            Console.WriteLine($"  Height at center before: {sqHeightBefore:F2}");
+
+            float sqFlatHeight = btd.FlattenSquare(sqCenterX, sqCenterY, halfW, halfH, blendWidth);
+            Console.WriteLine($"  Flattened to: {sqFlatHeight:F2}");
+
+            Console.WriteLine($"  Square samples (X axis):");
+            float[] sqOffsets = { 0, 128, 256, 384, 480, 640 };
+            foreach (float off in sqOffsets)
+            {
+                float h = btd.SampleHeightAtWorld(sqCenterX + off, sqCenterY);
+                string zone = off <= halfW ? "FLAT" : off <= halfW + blendWidth ? "BLEND" : "ORIGINAL";
+                Console.WriteLine($"    +{off,4:F0} units: {h,8:F2}  ({zone})");
+            }
+            Console.WriteLine($"  Square samples (Y axis):");
+            foreach (float off in new float[] { 0, 64, 128, 256, 350, 512 })
+            {
+                float h = btd.SampleHeightAtWorld(sqCenterX, sqCenterY + off);
+                string zone = off <= halfH ? "FLAT" : off <= halfH + blendWidth ? "BLEND" : "ORIGINAL";
+                Console.WriteLine($"    +{off,4:F0} units: {h,8:F2}  ({zone})");
+            }
+
+            Console.WriteLine($"  Smoothing cell edges...");
+            btd.SmoothDirtyCellEdges(32);
+
+            Console.WriteLine($"  Saving to {btdPath}...");
+            btd.Save(btdPath, updateMinMax: false);
+
+            Console.WriteLine("  Done.");
+            return 0;
+        }
+    }
+}

--- a/gen_btd_flatten.cs
+++ b/gen_btd_flatten.cs
@@ -22,16 +22,16 @@ namespace FrankyCLI
                 return 1;
             }
 
-            var reader = new BtdTerrainReader(btdPath);
+            var reader = new BtdFile(btdPath);
             Console.WriteLine($"  Cells: {reader.CellCountX}x{reader.CellCountY} ({reader.CellMinX},{reader.CellMinY}) to ({reader.CellMaxX},{reader.CellMaxY})");
             Console.WriteLine($"  Height range: {reader.WorldHeightMin} to {reader.WorldHeightMax}");
 
             float centerCellX = (reader.CellMinX + reader.CellMaxX) / 2.0f;
             float centerCellY = (reader.CellMinY + reader.CellMaxY) / 2.0f;
 
-            // Hill parameters — keep proportional to actual terrain heights (~15-84 world units)
-            float hillPeakHeight = 30f; // world units tall at the peak
-            float hillRadiusCells = 0.75f; // 3/4 of a cell radius
+            // Hill parameters — 100% bigger radius (1.5 cells)
+            float hillPeakHeight = 30f;
+            float hillRadiusCells = 1.5f;
             Console.WriteLine($"  Hill: peak {hillPeakHeight} units, radius {hillRadiusCells:F1} cells, center ({centerCellX}, {centerCellY})");
 
             int cellsModified = 0;
@@ -49,34 +49,19 @@ namespace FrankyCLI
             int safeMinY = reader.CellMinY + 1;
             int safeMaxY = reader.CellMaxY - 1;
 
-            // Read center cell's texture data to analyze the encoding
-            int centerCX = (int)centerCellX;
-            int centerCY = (int)centerCellY;
-            var sampleTex = new ushort[128 * 128];
-            reader.GetCellTextureData(sampleTex, centerCX, centerCY);
+            // Texture values: rocky top, sandy base
+            ushort texRocky = 0x0E00;  // "patchy sandy/rocky"
+            ushort texSandy = 0x4000;  // "clean bright sand"
+            Console.WriteLine($"  Textures: rocky=0x{texRocky:X4}, sandy=0x{texSandy:X4}");
 
-            // Find the unique texture values and their frequencies
-            var texFreq = new Dictionary<ushort, int>();
-            foreach (ushort v in sampleTex)
-            {
-                texFreq.TryGetValue(v, out int cnt);
-                texFreq[v] = cnt + 1;
-            }
-            var sorted = texFreq.OrderByDescending(kv => kv.Value).ToList();
-            Console.WriteLine($"  Texture analysis (center cell): {sorted.Count} unique values");
-            for (int i = 0; i < Math.Min(8, sorted.Count); i++)
-                Console.WriteLine($"    value={sorted[i].Key} (0x{sorted[i].Key:X4}) count={sorted[i].Value}");
-
-            // Pick a texture value for the hill:
-            // Use the least common of the top 3 values — should be visually distinct
-            ushort hillTexture;
-            if (sorted.Count >= 3)
-                hillTexture = sorted[2].Key; // 3rd most common
-            else if (sorted.Count >= 2)
-                hillTexture = sorted[1].Key;
-            else
-                hillTexture = sorted[0].Key;
-            Console.WriteLine($"  Hill texture value: {hillTexture} (0x{hillTexture:X4})");
+            // Normalize ALL cells' land texture maps
+            var canonicalPalette = new byte[32];
+            reader.GetCellLandTexMap(canonicalPalette, (int)centerCellX, (int)centerCellY);
+            for (int q = 1; q < 4; q++)
+                Array.Copy(canonicalPalette, 0, canonicalPalette, q * 8, 8);
+            for (int cy = reader.CellMinY; cy <= reader.CellMaxY; cy++)
+                for (int cx = reader.CellMinX; cx <= reader.CellMaxX; cx++)
+                    reader.SetCellLandTexMap(canonicalPalette, cx, cy);
 
             for (int cy = safeMinY; cy <= safeMaxY; cy++)
             {
@@ -87,15 +72,12 @@ namespace FrankyCLI
                     float cellWorldMaxX = cellWorldMinX + 127 * 32f;
                     float cellWorldMinY = cy * 4096f;
                     float cellWorldMaxY = cellWorldMinY + 127 * 32f;
-
-                    // Closest point on cell AABB to hill center
                     float nearX = Math.Clamp(worldCenterX, cellWorldMinX, cellWorldMaxX);
                     float nearY = Math.Clamp(worldCenterY, cellWorldMinY, cellWorldMaxY);
                     float nearDist = MathF.Sqrt((nearX - worldCenterX) * (nearX - worldCenterX) + (nearY - worldCenterY) * (nearY - worldCenterY));
                     if (nearDist > hillRadiusWorld)
-                        continue; // cell is entirely outside the hill
+                        continue;
 
-                    // Read existing height and texture data
                     var buf = new ushort[128 * 128];
                     reader.GetCellHeightMap(buf, cx, cy, 0);
                     var texBuf = new ushort[128 * 128];
@@ -108,25 +90,29 @@ namespace FrankyCLI
                         for (int vx = 0; vx < 128; vx++)
                         {
                             float wx = cx * 4096f + vx * 32f;
-
                             float distX = wx - worldCenterX;
                             float distY = wy - worldCenterY;
                             float dist = MathF.Sqrt(distX * distX + distY * distY);
 
                             if (dist <= hillRadiusWorld)
                             {
-                                // Smooth cosine hill added on top of existing terrain
                                 float t = dist / hillRadiusWorld;
                                 float hillHeight = hillPeakHeight * 0.5f * (1f + MathF.Cos(t * MathF.PI));
                                 float existing = reader.RawToHeight(buf[vy * 128 + vx]);
                                 buf[vy * 128 + vx] = reader.HeightToRaw(existing + hillHeight);
 
-                                // Paint texture on the inner 70% of the hill (leave edge for blending)
-                                if (t < 0.7f)
+                                // Rocky on top (inner 40%), sandy at base (outer 60%), blend in between
+                                if (t < 0.3f)
+                                    texBuf[vy * 128 + vx] = texRocky;
+                                else if (t > 0.6f)
+                                    texBuf[vy * 128 + vx] = texSandy;
+                                else
                                 {
-                                    texBuf[vy * 128 + vx] = hillTexture;
-                                    texelsModified++;
+                                    // Blend zone: interpolate between rocky and sandy values
+                                    float blend = (t - 0.3f) / 0.3f; // 0 at t=0.3, 1 at t=0.6
+                                    texBuf[vy * 128 + vx] = blend < 0.5f ? texRocky : texSandy;
                                 }
+                                texelsModified++;
 
                                 modified = true;
                                 vertsModified++;
@@ -138,6 +124,7 @@ namespace FrankyCLI
                     {
                         reader.SetCellHeightMap(buf, cx, cy);
                         reader.SetCellTextureData(texBuf, cx, cy);
+                        reader.SetCellLod4LandTex(new byte[128], cx, cy);
                         cellsModified++;
                     }
                 }
@@ -149,7 +136,6 @@ namespace FrankyCLI
             reader.SmoothDirtyCellEdges(32);
 
             Console.WriteLine($"  Saving to {btdPath}...");
-
             reader.Save(btdPath, updateMinMax: false);
 
             Console.WriteLine("  Done.");

--- a/gen_btd_flatten.cs
+++ b/gen_btd_flatten.cs
@@ -1,0 +1,159 @@
+using Retrograde.Utils;
+using System;
+using System.Linq;
+
+namespace FrankyCLI
+{
+    public class gen_btd_flatten
+    {
+        public static int Generate(string[] args)
+        {
+            string btdPath = @"C:\Program Files (x86)\Steam\steamapps\common\Starfield\Data\terrain\oebb008world.btd";
+
+            if (args.Length >= 6 && !string.IsNullOrWhiteSpace(args[5]))
+                btdPath = args[5];
+
+            Console.WriteLine($"=== BTD Flatten Tool ===");
+            Console.WriteLine($"File: {btdPath}");
+
+            if (!System.IO.File.Exists(btdPath))
+            {
+                Console.WriteLine($"ERROR: BTD file not found at '{btdPath}'");
+                return 1;
+            }
+
+            var reader = new BtdTerrainReader(btdPath);
+            Console.WriteLine($"  Cells: {reader.CellCountX}x{reader.CellCountY} ({reader.CellMinX},{reader.CellMinY}) to ({reader.CellMaxX},{reader.CellMaxY})");
+            Console.WriteLine($"  Height range: {reader.WorldHeightMin} to {reader.WorldHeightMax}");
+
+            float centerCellX = (reader.CellMinX + reader.CellMaxX) / 2.0f;
+            float centerCellY = (reader.CellMinY + reader.CellMaxY) / 2.0f;
+
+            // Hill parameters — keep proportional to actual terrain heights (~15-84 world units)
+            float hillPeakHeight = 30f; // world units tall at the peak
+            float hillRadiusCells = 0.75f; // 3/4 of a cell radius
+            Console.WriteLine($"  Hill: peak {hillPeakHeight} units, radius {hillRadiusCells:F1} cells, center ({centerCellX}, {centerCellY})");
+
+            int cellsModified = 0;
+            int vertsModified = 0;
+            int texelsModified = 0;
+
+            // World-space center of the map
+            float worldCenterX = centerCellX * 4096f + 2048f;
+            float worldCenterY = centerCellY * 4096f + 2048f;
+            float hillRadiusWorld = hillRadiusCells * 4096f;
+
+            // Figure out which cells the hill touches (skip edge cells)
+            int safeMinX = reader.CellMinX + 1;
+            int safeMaxX = reader.CellMaxX - 1;
+            int safeMinY = reader.CellMinY + 1;
+            int safeMaxY = reader.CellMaxY - 1;
+
+            // Read center cell's texture data to analyze the encoding
+            int centerCX = (int)centerCellX;
+            int centerCY = (int)centerCellY;
+            var sampleTex = new ushort[128 * 128];
+            reader.GetCellTextureData(sampleTex, centerCX, centerCY);
+
+            // Find the unique texture values and their frequencies
+            var texFreq = new Dictionary<ushort, int>();
+            foreach (ushort v in sampleTex)
+            {
+                texFreq.TryGetValue(v, out int cnt);
+                texFreq[v] = cnt + 1;
+            }
+            var sorted = texFreq.OrderByDescending(kv => kv.Value).ToList();
+            Console.WriteLine($"  Texture analysis (center cell): {sorted.Count} unique values");
+            for (int i = 0; i < Math.Min(8, sorted.Count); i++)
+                Console.WriteLine($"    value={sorted[i].Key} (0x{sorted[i].Key:X4}) count={sorted[i].Value}");
+
+            // Pick a texture value for the hill:
+            // Use the least common of the top 3 values — should be visually distinct
+            ushort hillTexture;
+            if (sorted.Count >= 3)
+                hillTexture = sorted[2].Key; // 3rd most common
+            else if (sorted.Count >= 2)
+                hillTexture = sorted[1].Key;
+            else
+                hillTexture = sorted[0].Key;
+            Console.WriteLine($"  Hill texture value: {hillTexture} (0x{hillTexture:X4})");
+
+            for (int cy = safeMinY; cy <= safeMaxY; cy++)
+            {
+                for (int cx = safeMinX; cx <= safeMaxX; cx++)
+                {
+                    // Check if this cell could overlap the hill at all
+                    float cellWorldMinX = cx * 4096f;
+                    float cellWorldMaxX = cellWorldMinX + 127 * 32f;
+                    float cellWorldMinY = cy * 4096f;
+                    float cellWorldMaxY = cellWorldMinY + 127 * 32f;
+
+                    // Closest point on cell AABB to hill center
+                    float nearX = Math.Clamp(worldCenterX, cellWorldMinX, cellWorldMaxX);
+                    float nearY = Math.Clamp(worldCenterY, cellWorldMinY, cellWorldMaxY);
+                    float nearDist = MathF.Sqrt((nearX - worldCenterX) * (nearX - worldCenterX) + (nearY - worldCenterY) * (nearY - worldCenterY));
+                    if (nearDist > hillRadiusWorld)
+                        continue; // cell is entirely outside the hill
+
+                    // Read existing height and texture data
+                    var buf = new ushort[128 * 128];
+                    reader.GetCellHeightMap(buf, cx, cy, 0);
+                    var texBuf = new ushort[128 * 128];
+                    reader.GetCellTextureData(texBuf, cx, cy);
+
+                    bool modified = false;
+                    for (int vy = 0; vy < 128; vy++)
+                    {
+                        float wy = cy * 4096f + vy * 32f;
+                        for (int vx = 0; vx < 128; vx++)
+                        {
+                            float wx = cx * 4096f + vx * 32f;
+
+                            float distX = wx - worldCenterX;
+                            float distY = wy - worldCenterY;
+                            float dist = MathF.Sqrt(distX * distX + distY * distY);
+
+                            if (dist <= hillRadiusWorld)
+                            {
+                                // Smooth cosine hill added on top of existing terrain
+                                float t = dist / hillRadiusWorld;
+                                float hillHeight = hillPeakHeight * 0.5f * (1f + MathF.Cos(t * MathF.PI));
+                                float existing = reader.RawToHeight(buf[vy * 128 + vx]);
+                                buf[vy * 128 + vx] = reader.HeightToRaw(existing + hillHeight);
+
+                                // Paint texture on the inner 70% of the hill (leave edge for blending)
+                                if (t < 0.7f)
+                                {
+                                    texBuf[vy * 128 + vx] = hillTexture;
+                                    texelsModified++;
+                                }
+
+                                modified = true;
+                                vertsModified++;
+                            }
+                        }
+                    }
+
+                    if (modified)
+                    {
+                        reader.SetCellHeightMap(buf, cx, cy);
+                        reader.SetCellTextureData(texBuf, cx, cy);
+                        cellsModified++;
+                    }
+                }
+            }
+
+            Console.WriteLine($"  Modified {vertsModified} verts, {texelsModified} texels in {cellsModified} cells");
+
+            Console.WriteLine($"  Smoothing cell edges...");
+            reader.SmoothDirtyCellEdges(32);
+
+            Console.WriteLine($"  Saving to {btdPath}...");
+
+            reader.Save(btdPath, updateMinMax: false);
+
+            Console.WriteLine("  Done.");
+            return 0;
+        }
+    }
+}

--- a/gen_btd_info.cs
+++ b/gen_btd_info.cs
@@ -13,6 +13,14 @@ namespace FrankyCLI
             if (args.Length >= 6 && !string.IsNullOrWhiteSpace(args[5]))
                 btdPath = args[5];
 
+            // If path is a directory, scan all BTD files in it
+            if (System.IO.Directory.Exists(btdPath))
+                return ScanAllBtdFiles(btdPath);
+
+            // Also check if it's a file in a directory — scan all if --all flag
+            if (args.Length >= 7 && args[6] == "--all" && System.IO.File.Exists(btdPath))
+                return ScanAllBtdFiles(System.IO.Path.GetDirectoryName(btdPath));
+
             Console.WriteLine($"=== BTD Info Dump ===");
             Console.WriteLine($"File: {btdPath}");
             Console.WriteLine();
@@ -42,7 +50,7 @@ namespace FrankyCLI
             Console.WriteLine();
 
             // --- Parsed header via reader ---
-            var reader = new BtdTerrainReader(btdPath);
+            var reader = new BtdFile(btdPath);
             Console.WriteLine("--- Parsed Header ---");
             Console.WriteLine($"  IsStarfield:     {reader.IsStarfield}");
             Console.WriteLine($"  CellMin:         ({reader.CellMinX}, {reader.CellMinY})");
@@ -257,30 +265,29 @@ namespace FrankyCLI
             }
             Console.WriteLine();
 
-            // --- Land texture map sample ---
-            Console.WriteLine("--- Land Texture Map (center cell, 32 bytes) ---");
+            // --- Land texture map for ALL cells ---
+            long ltexMapBase = cellHeightMinMaxOffs + (long)reader.CellCountY * reader.CellCountX * 8;
+            Console.WriteLine("--- Land Texture Map (32 bytes/cell) ---");
+            for (int cdy = 0; cdy < reader.CellCountY; cdy++)
             {
-                int cx = reader.CellCountX / 2;
-                int cy = reader.CellCountY / 2;
-                long off = cellHeightMinMaxOffs + (long)reader.CellCountY * reader.CellCountX * 8
-                         + ((long)cy * reader.CellCountX + cx) * 32;
-                Console.Write("  Hex:");
-                for (int i = 0; i < 32; i++)
-                    Console.Write($" {fileBytes[off + i]:X2}");
-                Console.WriteLine();
-                // Interpret as 8 uint32 values
-                Console.Write("  As uint32:");
-                for (int i = 0; i < 8; i++)
-                    Console.Write($" {ReadUInt32(fileBytes, off + i * 4)}");
-                Console.WriteLine();
-                // Interpret as 16 uint16 values
-                Console.Write("  As uint16:");
-                for (int i = 0; i < 16; i++)
+                for (int cdx = 0; cdx < reader.CellCountX; cdx++)
                 {
-                    ushort v = (ushort)(fileBytes[off + i * 2] | (fileBytes[off + i * 2 + 1] << 8));
-                    Console.Write($" {v}");
+                    int cellXp = cdx + reader.CellMinX;
+                    int cellYp = cdy + reader.CellMinY;
+                    long off = ltexMapBase + ((long)cdy * reader.CellCountX + cdx) * 32;
+                    Console.Write($"  Cell ({cellXp},{cellYp}) hex:");
+                    for (int i = 0; i < 32; i++)
+                        Console.Write($" {fileBytes[off + i]:X2}");
+                    Console.WriteLine();
+                    // Show as 4 groups of 8 bytes (possible quadrants)
+                    for (int q = 0; q < 4; q++)
+                    {
+                        Console.Write($"    Q{q}:");
+                        for (int i = 0; i < 8; i++)
+                            Console.Write($" LTEX[{fileBytes[off + q * 8 + i]}]");
+                        Console.WriteLine();
+                    }
                 }
-                Console.WriteLine();
             }
             Console.WriteLine();
 
@@ -311,11 +318,435 @@ namespace FrankyCLI
             }
             Console.WriteLine();
 
+            // --- Deep Texture Analysis (center cell) ---
+            Console.WriteLine("--- Deep Texture Analysis (center cell) ---");
+            {
+                int cx = reader.CellCountX / 2;
+                int cy = reader.CellCountY / 2;
+                int idx = cy * reader.CellCountX + cx;
+                long off = tableLOD0Offs + (long)idx * 8;
+                uint dataOff = ReadUInt32(fileBytes, off);
+                uint compSize = ReadUInt32(fileBytes, off + 4);
+                if (compSize > 0)
+                {
+                    long absOff = blockDataOffs + dataOff;
+                    byte[] decompressed = DecompressZlib(fileBytes, absOff, compSize, 65536);
+                    if (decompressed != null)
+                    {
+                        var texVals = new ushort[128 * 128];
+                        for (int i = 0; i < 128 * 128; i++)
+                        {
+                            int toff = 32768 + i * 2;
+                            texVals[i] = (ushort)(decompressed[toff] | (decompressed[toff + 1] << 8));
+                        }
+
+                        // Read cell's land texture map
+                        long ltexOff = ltexMapBase + ((long)cy * reader.CellCountX + cx) * 32;
+                        Console.WriteLine("  Cell land texture map (32 bytes):");
+                        Console.Write("    Bytes:");
+                        byte[] cellLtex = new byte[32];
+                        for (int i = 0; i < 32; i++)
+                        {
+                            cellLtex[i] = fileBytes[ltexOff + i];
+                            Console.Write($" {cellLtex[i]:X2}");
+                        }
+                        Console.WriteLine();
+                        for (int q = 0; q < 4; q++)
+                        {
+                            Console.Write($"    Q{q}:");
+                            for (int li = 0; li < 8; li++)
+                                Console.Write($" [{li}]=LTEX[{cellLtex[q * 8 + li]}]");
+                            Console.WriteLine();
+                        }
+                        Console.WriteLine();
+
+                        // Quadrant analysis: count layer usage in each quadrant of the 128x128 grid
+                        Console.WriteLine("  Quadrant texture layer analysis (layer = value >> 12):");
+                        int[][] qLayerCounts = new int[4][];
+                        for (int q = 0; q < 4; q++) qLayerCounts[q] = new int[8];
+                        for (int vy = 0; vy < 128; vy++)
+                        {
+                            // Quadrant: top-left=0, top-right=1, bottom-left=2, bottom-right=3
+                            int qy = vy < 64 ? 0 : 1;
+                            for (int vx = 0; vx < 128; vx++)
+                            {
+                                int qx = vx < 64 ? 0 : 1;
+                                int quad = qy * 2 + qx;
+                                int layer = texVals[vy * 128 + vx] >> 12;
+                                if (layer < 8) qLayerCounts[quad][layer]++;
+                            }
+                        }
+                        string[] qNames = { "TL(y<64,x<64)", "TR(y<64,x>=64)", "BL(y>=64,x<64)", "BR(y>=64,x>=64)" };
+                        for (int q = 0; q < 4; q++)
+                        {
+                            Console.Write($"    {qNames[q]}:");
+                            for (int li = 0; li < 8; li++)
+                                if (qLayerCounts[q][li] > 0)
+                                    Console.Write($" L{li}={qLayerCounts[q][li]}");
+                            Console.WriteLine();
+                        }
+                        Console.WriteLine();
+
+                        // Hypothesis 1: high byte = layer info, low byte = blend weight
+                        Console.WriteLine("  Hypothesis: highByte encodes layer, lowByte encodes weight");
+                        var highByteFreq = new Dictionary<byte, int>();
+                        foreach (ushort v in texVals)
+                        {
+                            byte hi = (byte)(v >> 8);
+                            highByteFreq.TryGetValue(hi, out int c);
+                            highByteFreq[hi] = c + 1;
+                        }
+                        var sortedHi = highByteFreq.OrderByDescending(kv => kv.Value).ToList();
+                        Console.WriteLine($"    Unique high bytes: {sortedHi.Count}");
+                        foreach (var kv in sortedHi.Take(16))
+                        {
+                            byte hi = kv.Key;
+                            // Find low byte range for this high byte
+                            int loMin = 256, loMax = -1;
+                            foreach (ushort v in texVals)
+                                if ((v >> 8) == hi)
+                                {
+                                    int lo = v & 0xFF;
+                                    if (lo < loMin) loMin = lo;
+                                    if (lo > loMax) loMax = lo;
+                                }
+                            Console.WriteLine($"    hi=0x{hi:X2} ({hi,3}) binary={Convert.ToString(hi, 2).PadLeft(8, '0')} count={kv.Value,6} lowRange=[{loMin}..{loMax}]");
+                        }
+                        Console.WriteLine();
+
+                        // Hypothesis 2: bits [15..N] = layer pair, bits [N-1..0] = blend
+                        // Try different bit splits
+                        Console.WriteLine("  Bit split analysis (value >> N):");
+                        for (int shift = 8; shift <= 13; shift++)
+                        {
+                            var groups = new Dictionary<int, int>();
+                            foreach (ushort v in texVals)
+                            {
+                                int grp = v >> shift;
+                                groups.TryGetValue(grp, out int c);
+                                groups[grp] = c + 1;
+                            }
+                            var sortedG = groups.OrderByDescending(kv => kv.Value).Take(10).ToList();
+                            Console.Write($"    >> {shift,2}: {groups.Count,3} groups, top:");
+                            foreach (var kv in sortedG.Take(8))
+                                Console.Write($" {kv.Key}({kv.Value})");
+                            Console.WriteLine();
+                        }
+                        Console.WriteLine();
+
+                        // Hypothesis 3: value encodes (layerA, layerB, blend)
+                        // If 8 layers, pairs = 8*8=64. Try value / N for various N
+                        Console.WriteLine("  Division analysis (value / N -> group count):");
+                        foreach (int divisor in new[] { 256, 512, 1024, 2048, 4096 })
+                        {
+                            var groups = new Dictionary<int, int>();
+                            foreach (ushort v in texVals)
+                            {
+                                int grp = v / divisor;
+                                groups.TryGetValue(grp, out int c);
+                                groups[grp] = c + 1;
+                            }
+                            var sortedG = groups.OrderBy(kv => kv.Key).ToList();
+                            Console.Write($"    / {divisor,4}: {groups.Count,3} groups:");
+                            foreach (var kv in sortedG)
+                                Console.Write($" {kv.Key}({kv.Value})");
+                            Console.WriteLine();
+                        }
+                        Console.WriteLine();
+
+                        // Show 16x16 spatial map of texture high bytes
+                        Console.WriteLine("  Spatial map (16x16, showing value >> 8):");
+                        for (int sy = 0; sy < 16; sy++)
+                        {
+                            Console.Write("    ");
+                            for (int sx = 0; sx < 16; sx++)
+                            {
+                                int vi = (sy * 8) * 128 + (sx * 8);
+                                Console.Write($"{texVals[vi] >> 8,3:X}");
+                            }
+                            Console.WriteLine();
+                        }
+                        Console.WriteLine();
+
+                        // Show 16x16 spatial map of full values
+                        Console.WriteLine("  Spatial map (16x16, full uint16 values):");
+                        for (int sy = 0; sy < 16; sy++)
+                        {
+                            Console.Write("    ");
+                            for (int sx = 0; sx < 16; sx++)
+                            {
+                                int vi = (sy * 8) * 128 + (sx * 8);
+                                Console.Write($"{texVals[vi],6}");
+                            }
+                            Console.WriteLine();
+                        }
+                        Console.WriteLine();
+
+                        // Show all cells' texture analysis for comparison
+                        Console.WriteLine("  Per-cell texture high byte distribution:");
+                        for (int cdy = 0; cdy < reader.CellCountY; cdy++)
+                        {
+                            for (int cdx = 0; cdx < reader.CellCountX; cdx++)
+                            {
+                                int ci = cdy * reader.CellCountX + cdx;
+                                long coff = tableLOD0Offs + (long)ci * 8;
+                                uint cdataOff = ReadUInt32(fileBytes, coff);
+                                uint ccompSize = ReadUInt32(fileBytes, coff + 4);
+                                if (ccompSize == 0) continue;
+
+                                long cabsOff = blockDataOffs + cdataOff;
+                                byte[] cdecomp = DecompressZlib(fileBytes, cabsOff, ccompSize, 65536);
+                                if (cdecomp == null) continue;
+
+                                var hiFreq = new Dictionary<byte, int>();
+                                for (int i = 0; i < 128 * 128; i++)
+                                {
+                                    int toff2 = 32768 + i * 2;
+                                    byte hi = cdecomp[toff2 + 1];
+                                    hiFreq.TryGetValue(hi, out int c);
+                                    hiFreq[hi] = c + 1;
+                                }
+                                var topHi = hiFreq.OrderByDescending(kv => kv.Value).Take(5).ToList();
+                                int cellXp = cdx + reader.CellMinX;
+                                int cellYp = cdy + reader.CellMinY;
+                                Console.Write($"    Cell ({cellXp,2},{cellYp,2}):");
+                                foreach (var kv in topHi)
+                                    Console.Write($" 0x{kv.Key:X2}={kv.Value}");
+
+                                // Also show this cell's land texture map
+                                long cltexOff = ltexMapBase + ((long)cdy * reader.CellCountX + cdx) * 32;
+                                Console.Write("  ltex:");
+                                for (int i = 0; i < 8; i++)
+                                    Console.Write($" {fileBytes[cltexOff + i]}");
+                                Console.WriteLine();
+                            }
+                        }
+                    }
+                }
+            }
+            Console.WriteLine();
+
             Console.WriteLine("=== Done ===");
             return 0;
         }
 
-        private static void PrintCellMinMax(byte[] data, long baseOffs, BtdTerrainReader reader, int dx, int dy, string label)
+        private static int ScanAllBtdFiles(string directory)
+        {
+            var btdFiles = System.IO.Directory.GetFiles(directory, "*.btd")
+                .OrderBy(f => f)
+                .ToArray();
+
+            Console.WriteLine($"=== BTD Multi-File Scan ===");
+            Console.WriteLine($"Directory: {directory}");
+            Console.WriteLine($"Found {btdFiles.Length} BTD files");
+            Console.WriteLine();
+
+            foreach (var filePath in btdFiles)
+            {
+                string fileName = System.IO.Path.GetFileName(filePath);
+                byte[] fileBytes;
+                try { fileBytes = System.IO.File.ReadAllBytes(filePath); }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"--- {fileName}: ERROR reading: {ex.Message}");
+                    Console.WriteLine();
+                    continue;
+                }
+
+                if (fileBytes.Length < 0x28)
+                {
+                    Console.WriteLine($"--- {fileName}: TOO SMALL ({fileBytes.Length} bytes)");
+                    Console.WriteLine();
+                    continue;
+                }
+
+                string magic = $"{(char)fileBytes[0]}{(char)fileBytes[1]}{(char)fileBytes[2]}{(char)fileBytes[3]}";
+                uint version = ReadUInt32(fileBytes, 0x04);
+                float heightMin = ReadFloat(fileBytes, 0x08);
+                float heightMax = ReadFloat(fileBytes, 0x0C);
+
+                BtdFile reader;
+                try { reader = new BtdFile(filePath); }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"--- {fileName}: PARSE ERROR: {ex.Message}");
+                    Console.WriteLine();
+                    continue;
+                }
+
+                Console.WriteLine($"--- {fileName} ---");
+                Console.WriteLine($"  Size: {fileBytes.Length / 1024.0 / 1024.0:F2} MB, Magic: {magic}, Version: {version}");
+                Console.WriteLine($"  IsStarfield: {reader.IsStarfield}");
+                Console.WriteLine($"  Cells: {reader.CellCountX}x{reader.CellCountY} ({reader.CellMinX},{reader.CellMinY}) to ({reader.CellMaxX},{reader.CellMaxY})");
+                Console.WriteLine($"  Height range: {heightMin:F2} to {heightMax:F2} (span {heightMax - heightMin:F2})");
+
+                // LTEX count
+                long pos = 0x28;
+                uint ltexCnt = ReadUInt32(fileBytes, pos);
+                Console.WriteLine($"  LTEX count: {ltexCnt}");
+                pos += 4;
+
+                // Show first few LTEX form IDs
+                int ltexShow = (int)Math.Min(ltexCnt, 8);
+                Console.Write("    LTEX IDs:");
+                for (int i = 0; i < ltexShow; i++)
+                {
+                    uint fid = ReadUInt32(fileBytes, pos + i * 4);
+                    Console.Write($" 0x{fid:X8}");
+                }
+                if (ltexCnt > 8) Console.Write($" ... +{ltexCnt - 8} more");
+                Console.WriteLine();
+                pos += ltexCnt * 4;
+
+                // Cell height min/max map
+                long cellHeightMinMaxOffs = pos;
+                pos += (long)reader.CellCountY * reader.CellCountX * 8;
+
+                // Land texture map
+                long ltexMapOffs = pos;
+                pos += (long)reader.CellCountY * reader.CellCountX * 32;
+
+                // GCVR for non-Starfield
+                if (!reader.IsStarfield)
+                {
+                    uint gcvrCnt = ReadUInt32(fileBytes, pos);
+                    Console.WriteLine($"  GCVR count: {gcvrCnt}");
+                    pos += 4 + gcvrCnt * 4;
+                    pos += (long)reader.CellCountY * reader.CellCountX * 32;
+                }
+
+                // LOD4 sections
+                pos += (long)reader.CellCountY * reader.CellCountX * 128; // LOD4 height
+                pos += (long)reader.CellCountY * reader.CellCountX * 128; // LOD4 land tex
+
+                if (!reader.IsStarfield)
+                    pos += (long)reader.CellCountY * reader.CellCountX * 128; // vertex color
+
+                // Block tables
+                int countX = reader.CellCountX;
+                int countY = reader.CellCountY;
+                int gridLOD3 = CeilDiv(countY, 8) * CeilDiv(countX, 8);
+                int gridLOD2 = CeilDiv(countY, 4) * CeilDiv(countX, 4);
+                int gridLOD1 = CeilDiv(countY, 2) * CeilDiv(countX, 2);
+                int gridLOD0 = countY * countX;
+
+                pos += (long)gridLOD3 * (reader.IsStarfield ? 8 : 16);
+                pos += (long)gridLOD2 * (reader.IsStarfield ? 8 : 16);
+                long tableLOD1Offs = pos;
+                pos += (long)gridLOD1 * 8;
+                long tableLOD0Offs = pos;
+                pos += (long)gridLOD0 * (reader.IsStarfield ? 8 : 16);
+                long blockDataOffs = pos;
+
+                Console.WriteLine($"  Block data offset: 0x{blockDataOffs:X}, data size: {(fileBytes.Length - blockDataOffs) / 1024.0 / 1024.0:F2} MB");
+
+                // LOD0 block stats
+                int lod0Empty = 0;
+                uint lod0TotalComp = 0;
+                for (int i = 0; i < gridLOD0; i++)
+                {
+                    long off = tableLOD0Offs + (long)i * (reader.IsStarfield ? 8 : 16);
+                    uint compSize = ReadUInt32(fileBytes, off + 4);
+                    if (compSize == 0) lod0Empty++;
+                    else lod0TotalComp += compSize;
+                }
+                Console.WriteLine($"  LOD0: {gridLOD0} blocks, {gridLOD0 - lod0Empty} non-empty, {lod0Empty} empty");
+
+                // Analyze land texture maps — check quadrant consistency
+                int cellsWithUniformQuads = 0;
+                int cellsWithDifferentQuads = 0;
+                int totalCells = reader.CellCountX * reader.CellCountY;
+                var uniquePalettes = new System.Collections.Generic.HashSet<string>();
+
+                for (int cdy = 0; cdy < reader.CellCountY; cdy++)
+                {
+                    for (int cdx = 0; cdx < reader.CellCountX; cdx++)
+                    {
+                        long off = ltexMapOffs + ((long)cdy * reader.CellCountX + cdx) * 32;
+                        bool quadsMatch = true;
+                        for (int q = 1; q < 4; q++)
+                        {
+                            for (int b = 0; b < 8; b++)
+                            {
+                                if (fileBytes[off + q * 8 + b] != fileBytes[off + b])
+                                {
+                                    quadsMatch = false;
+                                    break;
+                                }
+                            }
+                            if (!quadsMatch) break;
+                        }
+                        if (quadsMatch) cellsWithUniformQuads++;
+                        else cellsWithDifferentQuads++;
+
+                        // Collect unique Q0 palettes
+                        var palStr = string.Join(",", Enumerable.Range(0, 8).Select(i => fileBytes[off + i].ToString()));
+                        uniquePalettes.Add(palStr);
+                    }
+                }
+                Console.WriteLine($"  Land tex map: {cellsWithUniformQuads}/{totalCells} uniform quads, {cellsWithDifferentQuads} with quad differences");
+                Console.WriteLine($"  Unique Q0 palettes: {uniquePalettes.Count}");
+
+                // Show a few palette examples
+                int shown = 0;
+                foreach (var pal in uniquePalettes.Take(5))
+                {
+                    Console.WriteLine($"    Palette: [{pal}]");
+                    shown++;
+                }
+                if (uniquePalettes.Count > 5)
+                    Console.WriteLine($"    ... +{uniquePalettes.Count - 5} more");
+
+                // Sample texture values from center cell LOD0 block
+                int centerIdx = (reader.CellCountY / 2) * reader.CellCountX + (reader.CellCountX / 2);
+                long centerOff = tableLOD0Offs + (long)centerIdx * (reader.IsStarfield ? 8 : 16);
+                uint centerDataOff = ReadUInt32(fileBytes, centerOff);
+                uint centerCompSize = ReadUInt32(fileBytes, centerOff + 4);
+                if (centerCompSize > 0)
+                {
+                    long absOff = blockDataOffs + centerDataOff;
+                    byte[] decompressed = DecompressZlib(fileBytes, absOff, centerCompSize, 65536);
+                    if (decompressed != null)
+                    {
+                        // Texture value distribution from center cell
+                        var valFreq = new System.Collections.Generic.Dictionary<ushort, int>();
+                        ushort texMin = ushort.MaxValue, texMax = 0;
+                        for (int i = 0; i < 128 * 128; i++)
+                        {
+                            int toff = 32768 + i * 2;
+                            ushort v = (ushort)(decompressed[toff] | (decompressed[toff + 1] << 8));
+                            if (v < texMin) texMin = v;
+                            if (v > texMax) texMax = v;
+                            valFreq.TryGetValue(v, out int c);
+                            valFreq[v] = c + 1;
+                        }
+                        Console.WriteLine($"  Center cell textures: {valFreq.Count} unique values, range 0x{texMin:X4}..0x{texMax:X4}");
+                        var topVals = valFreq.OrderByDescending(kv => kv.Value).Take(8).ToList();
+                        Console.Write("    Top values:");
+                        foreach (var kv in topVals)
+                            Console.Write($" 0x{kv.Key:X4}({kv.Value})");
+                        Console.WriteLine();
+
+                        // Height stats from center cell
+                        ushort hMin = ushort.MaxValue, hMax = 0;
+                        for (int i = 0; i < 128 * 128; i++)
+                        {
+                            ushort v = (ushort)(decompressed[i * 2] | (decompressed[i * 2 + 1] << 8));
+                            if (v < hMin) hMin = v;
+                            if (v > hMax) hMax = v;
+                        }
+                        Console.WriteLine($"  Center cell heights: raw [{hMin}..{hMax}], world [{reader.RawToHeight(hMin):F2}..{reader.RawToHeight(hMax):F2}]");
+                    }
+                }
+
+                Console.WriteLine();
+            }
+
+            Console.WriteLine("=== Scan Complete ===");
+            return 0;
+        }
+
+        private static void PrintCellMinMax(byte[] data, long baseOffs, BtdFile reader, int dx, int dy, string label)
         {
             long off = baseOffs + ((long)dy * reader.CellCountX + dx) * 8;
             float cMin = ReadFloat(data, off);
@@ -347,7 +778,7 @@ namespace FrankyCLI
             }
         }
 
-        private static void AnalyzeUint16Region(byte[] data, int byteOffset, int count, string label, BtdTerrainReader reader)
+        private static void AnalyzeUint16Region(byte[] data, int byteOffset, int count, string label, BtdFile reader)
         {
             ushort min = ushort.MaxValue, max = ushort.MinValue;
             long sum = 0;

--- a/gen_btd_info.cs
+++ b/gen_btd_info.cs
@@ -1,0 +1,415 @@
+using Retrograde.Utils;
+using System;
+using System.Linq;
+
+namespace FrankyCLI
+{
+    public class gen_btd_info
+    {
+        public static int Generate(string[] args)
+        {
+            string btdPath = @"C:\Program Files (x86)\Steam\steamapps\common\Starfield\Data\terrain\oebb008world.btd";
+
+            if (args.Length >= 6 && !string.IsNullOrWhiteSpace(args[5]))
+                btdPath = args[5];
+
+            Console.WriteLine($"=== BTD Info Dump ===");
+            Console.WriteLine($"File: {btdPath}");
+            Console.WriteLine();
+
+            if (!System.IO.File.Exists(btdPath))
+            {
+                Console.WriteLine($"ERROR: BTD file not found at '{btdPath}'");
+                return 1;
+            }
+
+            var fileBytes = System.IO.File.ReadAllBytes(btdPath);
+            Console.WriteLine($"File size: {fileBytes.Length:N0} bytes ({fileBytes.Length / 1024.0 / 1024.0:F2} MB)");
+            Console.WriteLine();
+
+            // --- Raw header bytes ---
+            Console.WriteLine("--- Raw Header (0x00-0x27) ---");
+            Console.WriteLine($"  [0x00] Magic:        {(char)fileBytes[0]}{(char)fileBytes[1]}{(char)fileBytes[2]}{(char)fileBytes[3]}");
+            Console.WriteLine($"  [0x04] Version:      {ReadUInt32(fileBytes, 0x04)}");
+            Console.WriteLine($"  [0x08] HeightMin:    {ReadFloat(fileBytes, 0x08)}");
+            Console.WriteLine($"  [0x0C] HeightMax:    {ReadFloat(fileBytes, 0x0C)}");
+            Console.WriteLine($"  [0x10] ResX:         {ReadUInt32(fileBytes, 0x10)} (0x{ReadUInt32(fileBytes, 0x10):X8})");
+            Console.WriteLine($"  [0x14] ResY:         {ReadUInt32(fileBytes, 0x14)} (0x{ReadUInt32(fileBytes, 0x14):X8})");
+            Console.WriteLine($"  [0x18] CellMinX:     {ReadInt32(fileBytes, 0x18)}");
+            Console.WriteLine($"  [0x1C] CellMinY:     {ReadInt32(fileBytes, 0x1C)}");
+            Console.WriteLine($"  [0x20] CellMaxX:     {ReadInt32(fileBytes, 0x20)}");
+            Console.WriteLine($"  [0x24] CellMaxY:     {ReadInt32(fileBytes, 0x24)}");
+            Console.WriteLine();
+
+            // --- Parsed header via reader ---
+            var reader = new BtdTerrainReader(btdPath);
+            Console.WriteLine("--- Parsed Header ---");
+            Console.WriteLine($"  IsStarfield:     {reader.IsStarfield}");
+            Console.WriteLine($"  CellMin:         ({reader.CellMinX}, {reader.CellMinY})");
+            Console.WriteLine($"  CellMax:         ({reader.CellMaxX}, {reader.CellMaxY})");
+            Console.WriteLine($"  CellCount:       {reader.CellCountX} x {reader.CellCountY} = {reader.CellCountX * reader.CellCountY} cells");
+            Console.WriteLine($"  WorldHeightMin:  {reader.WorldHeightMin:F4}");
+            Console.WriteLine($"  WorldHeightMax:  {reader.WorldHeightMax:F4}");
+            Console.WriteLine($"  HeightRange:     {reader.WorldHeightMax - reader.WorldHeightMin:F4}");
+            Console.WriteLine($"  RawToHeight(0):      {reader.RawToHeight(0):F4}");
+            Console.WriteLine($"  RawToHeight(32768):  {reader.RawToHeight(32768):F4}");
+            Console.WriteLine($"  RawToHeight(65535):  {reader.RawToHeight(65535):F4}");
+            Console.WriteLine($"  HeightToRaw(0):      {reader.HeightToRaw(0f)}");
+            Console.WriteLine();
+
+            // --- Section layout ---
+            // Walk the file the same way CalculateSectionOffsets does, but print everything
+            Console.WriteLine("--- Section Layout ---");
+            long pos = 0x28;
+            uint ltexCnt = ReadUInt32(fileBytes, pos);
+            Console.WriteLine($"  [0x{pos:X8}] LTEX form ID count: {ltexCnt}");
+            pos += 4;
+
+            // Print a few LTEX form IDs
+            int ltexShow = (int)Math.Min(ltexCnt, 10);
+            for (int i = 0; i < ltexShow; i++)
+            {
+                uint fid = ReadUInt32(fileBytes, pos + i * 4);
+                Console.WriteLine($"    LTEX[{i}]: 0x{fid:X8}");
+            }
+            if (ltexCnt > 10) Console.WriteLine($"    ... ({ltexCnt - 10} more)");
+            pos += ltexCnt * 4;
+
+            long cellHeightMinMaxOffs = pos;
+            long cellHeightMinMaxSize = (long)reader.CellCountY * reader.CellCountX * 8;
+            Console.WriteLine($"  [0x{pos:X8}] Cell height min/max map: {cellHeightMinMaxSize:N0} bytes ({reader.CellCountX}x{reader.CellCountY} cells, 8 bytes each)");
+            pos += cellHeightMinMaxSize;
+
+            long ltexMapSize = (long)reader.CellCountY * reader.CellCountX * 32;
+            Console.WriteLine($"  [0x{pos:X8}] Land texture map: {ltexMapSize:N0} bytes (32 bytes/cell)");
+            pos += ltexMapSize;
+
+            if (!reader.IsStarfield)
+            {
+                uint gcvrCnt = ReadUInt32(fileBytes, pos);
+                Console.WriteLine($"  [0x{pos:X8}] GCVR form ID count: {gcvrCnt}");
+                pos += 4;
+                pos += gcvrCnt * 4;
+                long gcvrMapSize = (long)reader.CellCountY * reader.CellCountX * 32;
+                Console.WriteLine($"  [0x{pos:X8}] Ground cover map: {gcvrMapSize:N0} bytes");
+                pos += gcvrMapSize;
+            }
+
+            long lod4HeightOffs = pos;
+            long lod4HeightSize = (long)reader.CellCountY * reader.CellCountX * 128;
+            Console.WriteLine($"  [0x{pos:X8}] LOD4 height map: {lod4HeightSize:N0} bytes (128 bytes/cell, 8x8 grid of uint16)");
+            pos += lod4HeightSize;
+
+            long lod4LtexSize = (long)reader.CellCountY * reader.CellCountX * 128;
+            Console.WriteLine($"  [0x{pos:X8}] LOD4 land textures: {lod4LtexSize:N0} bytes (128 bytes/cell)");
+            pos += lod4LtexSize;
+
+            if (!reader.IsStarfield)
+            {
+                long vclrSize = (long)reader.CellCountY * reader.CellCountX * 128;
+                Console.WriteLine($"  [0x{pos:X8}] Vertex color LOD4: {vclrSize:N0} bytes");
+                pos += vclrSize;
+            }
+
+            // Block tables
+            int countX = reader.CellCountX;
+            int countY = reader.CellCountY;
+            int entriesPerBlock = reader.IsStarfield ? 1 : 2;
+
+            int gridLOD3 = CeilDiv(countY, 8) * CeilDiv(countX, 8);
+            long tableLOD3Size = (long)gridLOD3 * (reader.IsStarfield ? 8 : 16);
+            Console.WriteLine($"  [0x{pos:X8}] Block table LOD3: {gridLOD3} blocks, {tableLOD3Size:N0} bytes");
+            long tableLOD3Offs = pos;
+            pos += tableLOD3Size;
+
+            int gridLOD2 = CeilDiv(countY, 4) * CeilDiv(countX, 4);
+            long tableLOD2Size = (long)gridLOD2 * (reader.IsStarfield ? 8 : 16);
+            Console.WriteLine($"  [0x{pos:X8}] Block table LOD2: {gridLOD2} blocks, {tableLOD2Size:N0} bytes");
+            long tableLOD2Offs = pos;
+            pos += tableLOD2Size;
+
+            int gridLOD1 = CeilDiv(countY, 2) * CeilDiv(countX, 2);
+            long tableLOD1Size = (long)gridLOD1 * 8;
+            Console.WriteLine($"  [0x{pos:X8}] Block table LOD1: {gridLOD1} blocks, {tableLOD1Size:N0} bytes");
+            long tableLOD1Offs = pos;
+            pos += tableLOD1Size;
+
+            int gridLOD0 = countY * countX;
+            long tableLOD0Size = (long)gridLOD0 * (reader.IsStarfield ? 8 : 16);
+            Console.WriteLine($"  [0x{pos:X8}] Block table LOD0: {gridLOD0} blocks, {tableLOD0Size:N0} bytes");
+            long tableLOD0Offs = pos;
+            pos += tableLOD0Size;
+
+            Console.WriteLine($"  [0x{pos:X8}] Compressed block data starts");
+            long blockDataOffs = pos;
+            Console.WriteLine($"  Prefix size: {blockDataOffs:N0} bytes ({blockDataOffs / 1024.0:F1} KB)");
+            Console.WriteLine($"  Block data size: {fileBytes.Length - blockDataOffs:N0} bytes ({(fileBytes.Length - blockDataOffs) / 1024.0 / 1024.0:F2} MB)");
+            Console.WriteLine();
+
+            // --- Cell height min/max sample ---
+            Console.WriteLine("--- Cell Height Min/Max (sample) ---");
+            float globalMin = float.MaxValue;
+            float globalMax = float.MinValue;
+            int uniformCells = 0;
+            for (int dy = 0; dy < reader.CellCountY; dy++)
+            {
+                for (int dx = 0; dx < reader.CellCountX; dx++)
+                {
+                    long off = cellHeightMinMaxOffs + ((long)dy * reader.CellCountX + dx) * 8;
+                    float cMin = ReadFloat(fileBytes, off);
+                    float cMax = ReadFloat(fileBytes, off + 4);
+                    if (cMin < globalMin) globalMin = cMin;
+                    if (cMax > globalMax) globalMax = cMax;
+                    if (Math.Abs(cMax - cMin) < 0.01f) uniformCells++;
+                }
+            }
+            Console.WriteLine($"  Global cell min: {globalMin:F4}");
+            Console.WriteLine($"  Global cell max: {globalMax:F4}");
+            Console.WriteLine($"  Uniform cells (min==max): {uniformCells} / {reader.CellCountX * reader.CellCountY}");
+
+            // Print corners and center
+            PrintCellMinMax(fileBytes, cellHeightMinMaxOffs, reader, 0, 0, "Top-left");
+            PrintCellMinMax(fileBytes, cellHeightMinMaxOffs, reader, reader.CellCountX - 1, 0, "Top-right");
+            PrintCellMinMax(fileBytes, cellHeightMinMaxOffs, reader, 0, reader.CellCountY - 1, "Bottom-left");
+            PrintCellMinMax(fileBytes, cellHeightMinMaxOffs, reader, reader.CellCountX - 1, reader.CellCountY - 1, "Bottom-right");
+            PrintCellMinMax(fileBytes, cellHeightMinMaxOffs, reader, reader.CellCountX / 2, reader.CellCountY / 2, "Center");
+            Console.WriteLine();
+
+            // --- Block table stats per LOD ---
+            Console.WriteLine("--- Compressed Block Stats ---");
+            PrintBlockStats(fileBytes, "LOD3", tableLOD3Offs, gridLOD3, reader.IsStarfield ? 1 : 2);
+            PrintBlockStats(fileBytes, "LOD2", tableLOD2Offs, gridLOD2, reader.IsStarfield ? 1 : 2);
+            PrintBlockStats(fileBytes, "LOD1", tableLOD1Offs, gridLOD1, 1);
+            PrintBlockStats(fileBytes, "LOD0", tableLOD0Offs, gridLOD0, reader.IsStarfield ? 1 : 2);
+            Console.WriteLine();
+
+            // --- LOD0 decompressed block analysis ---
+            Console.WriteLine("--- LOD0 Block Content Analysis (first non-empty block) ---");
+            for (int i = 0; i < gridLOD0; i++)
+            {
+                long off = tableLOD0Offs + (long)i * 8;
+                uint dataOff = ReadUInt32(fileBytes, off);
+                uint compSize = ReadUInt32(fileBytes, off + 4);
+                if (compSize == 0) continue;
+
+                long absOff = blockDataOffs + dataOff;
+                byte[] decompressed = DecompressZlib(fileBytes, absOff, compSize, 65536);
+                if (decompressed == null) continue;
+
+                int cellX = i % reader.CellCountX + reader.CellMinX;
+                int cellY = i / reader.CellCountX + reader.CellMinY;
+                Console.WriteLine($"  Block {i} = cell ({cellX},{cellY}), compressed {compSize:N0} -> {decompressed.Length:N0} bytes");
+                Console.WriteLine($"  Compression ratio: {(float)compSize / decompressed.Length:P1}");
+
+                // Height portion: first 128*128*2 = 32768 bytes
+                AnalyzeUint16Region(decompressed, 0, 128 * 128, "Height (0..32767)", reader);
+
+                // Texture portion: next 128*128*2 = 32768 bytes
+                AnalyzeUint16Region(decompressed, 32768, 128 * 128, "Texture (32768..65535)", null);
+
+                break; // just the first one
+            }
+            Console.WriteLine();
+
+            // --- LOD0 center block analysis ---
+            Console.WriteLine("--- LOD0 Center Block Analysis ---");
+            {
+                int cx = reader.CellCountX / 2;
+                int cy = reader.CellCountY / 2;
+                int idx = cy * reader.CellCountX + cx;
+                long off = tableLOD0Offs + (long)idx * 8;
+                uint dataOff = ReadUInt32(fileBytes, off);
+                uint compSize = ReadUInt32(fileBytes, off + 4);
+                if (compSize > 0)
+                {
+                    long absOff = blockDataOffs + dataOff;
+                    byte[] decompressed = DecompressZlib(fileBytes, absOff, compSize, 65536);
+                    if (decompressed != null)
+                    {
+                        int cellX = cx + reader.CellMinX;
+                        int cellY = cy + reader.CellMinY;
+                        Console.WriteLine($"  Center cell ({cellX},{cellY}), compressed {compSize:N0} -> {decompressed.Length:N0} bytes");
+                        AnalyzeUint16Region(decompressed, 0, 128 * 128, "Height", reader);
+                        AnalyzeUint16Region(decompressed, 32768, 128 * 128, "Texture", null);
+                    }
+                }
+            }
+            Console.WriteLine();
+
+            // --- LOD4 height map sample ---
+            Console.WriteLine("--- LOD4 Height Map (center cell) ---");
+            {
+                int cx = reader.CellCountX / 2;
+                int cy = reader.CellCountY / 2;
+                long off = lod4HeightOffs + ((long)cy * reader.CellCountX + cx) * 128;
+                Console.WriteLine($"  Cell ({cx + reader.CellMinX},{cy + reader.CellMinY}), 8x8 grid:");
+                for (int ly = 0; ly < 8; ly++)
+                {
+                    Console.Write("    ");
+                    for (int lx = 0; lx < 8; lx++)
+                    {
+                        ushort v = (ushort)(fileBytes[off] | (fileBytes[off + 1] << 8));
+                        off += 2;
+                        Console.Write($"{reader.RawToHeight(v),9:F1} ");
+                    }
+                    Console.WriteLine();
+                }
+            }
+            Console.WriteLine();
+
+            // --- Land texture map sample ---
+            Console.WriteLine("--- Land Texture Map (center cell, 32 bytes) ---");
+            {
+                int cx = reader.CellCountX / 2;
+                int cy = reader.CellCountY / 2;
+                long off = cellHeightMinMaxOffs + (long)reader.CellCountY * reader.CellCountX * 8
+                         + ((long)cy * reader.CellCountX + cx) * 32;
+                Console.Write("  Hex:");
+                for (int i = 0; i < 32; i++)
+                    Console.Write($" {fileBytes[off + i]:X2}");
+                Console.WriteLine();
+                // Interpret as 8 uint32 values
+                Console.Write("  As uint32:");
+                for (int i = 0; i < 8; i++)
+                    Console.Write($" {ReadUInt32(fileBytes, off + i * 4)}");
+                Console.WriteLine();
+                // Interpret as 16 uint16 values
+                Console.Write("  As uint16:");
+                for (int i = 0; i < 16; i++)
+                {
+                    ushort v = (ushort)(fileBytes[off + i * 2] | (fileBytes[off + i * 2 + 1] << 8));
+                    Console.Write($" {v}");
+                }
+                Console.WriteLine();
+            }
+            Console.WriteLine();
+
+            // --- Height distribution across all cells ---
+            Console.WriteLine("--- Height Distribution (via cell min/max metadata) ---");
+            int[] buckets = new int[10];
+            float range = reader.WorldHeightMax - reader.WorldHeightMin;
+            for (int dy = 0; dy < reader.CellCountY; dy++)
+            {
+                for (int dx = 0; dx < reader.CellCountX; dx++)
+                {
+                    long off = cellHeightMinMaxOffs + ((long)dy * reader.CellCountX + dx) * 8;
+                    float cMin = ReadFloat(fileBytes, off);
+                    float cMax = ReadFloat(fileBytes, off + 4);
+                    float mid = (cMin + cMax) / 2f;
+                    int bucket = (int)((mid - reader.WorldHeightMin) / range * (buckets.Length - 1));
+                    bucket = Math.Clamp(bucket, 0, buckets.Length - 1);
+                    buckets[bucket]++;
+                }
+            }
+            int maxBucket = buckets.Max();
+            for (int i = 0; i < buckets.Length; i++)
+            {
+                float lo = reader.WorldHeightMin + range * i / buckets.Length;
+                float hi = reader.WorldHeightMin + range * (i + 1) / buckets.Length;
+                int barLen = maxBucket > 0 ? buckets[i] * 40 / maxBucket : 0;
+                Console.WriteLine($"  [{lo,10:F1} .. {hi,10:F1}] {new string('#', barLen)} ({buckets[i]})");
+            }
+            Console.WriteLine();
+
+            Console.WriteLine("=== Done ===");
+            return 0;
+        }
+
+        private static void PrintCellMinMax(byte[] data, long baseOffs, BtdTerrainReader reader, int dx, int dy, string label)
+        {
+            long off = baseOffs + ((long)dy * reader.CellCountX + dx) * 8;
+            float cMin = ReadFloat(data, off);
+            float cMax = ReadFloat(data, off + 4);
+            Console.WriteLine($"  {label} ({dx + reader.CellMinX},{dy + reader.CellMinY}): min={cMin:F2}, max={cMax:F2}");
+        }
+
+        private static void PrintBlockStats(byte[] data, string label, long tableOffs, int blockCount, int entriesPerBlock)
+        {
+            int empty = 0;
+            uint totalCompressed = 0;
+            uint minSize = uint.MaxValue;
+            uint maxSize = 0;
+            for (int i = 0; i < blockCount; i++)
+            {
+                long off = tableOffs + (long)i * entriesPerBlock * 8;
+                uint compSize = ReadUInt32(data, off + 4);
+                if (compSize == 0) { empty++; continue; }
+                totalCompressed += compSize;
+                if (compSize < minSize) minSize = compSize;
+                if (compSize > maxSize) maxSize = compSize;
+            }
+            int nonEmpty = blockCount - empty;
+            Console.WriteLine($"  {label}: {blockCount} blocks, {nonEmpty} non-empty, {empty} empty");
+            if (nonEmpty > 0)
+            {
+                Console.WriteLine($"    Total compressed: {totalCompressed:N0} bytes ({totalCompressed / 1024.0 / 1024.0:F2} MB)");
+                Console.WriteLine($"    Size range: {minSize:N0} .. {maxSize:N0} bytes, avg {totalCompressed / nonEmpty:N0}");
+            }
+        }
+
+        private static void AnalyzeUint16Region(byte[] data, int byteOffset, int count, string label, BtdTerrainReader reader)
+        {
+            ushort min = ushort.MaxValue, max = ushort.MinValue;
+            long sum = 0;
+            int zeroCount = 0;
+            int maxValCount = 0;
+            ushort[] histogram = new ushort[256]; // coarse histogram
+
+            for (int i = 0; i < count; i++)
+            {
+                int off = byteOffset + i * 2;
+                ushort v = (ushort)(data[off] | (data[off + 1] << 8));
+                if (v < min) min = v;
+                if (v > max) max = v;
+                sum += v;
+                if (v == 0) zeroCount++;
+                if (v == 65535) maxValCount++;
+                histogram[v >> 8]++;
+            }
+
+            Console.WriteLine($"  {label}: raw [{min}..{max}], avg {sum / (double)count:F1}, zeros={zeroCount}, maxvals={maxValCount}");
+            if (reader != null)
+                Console.WriteLine($"    World height: [{reader.RawToHeight(min):F2}..{reader.RawToHeight(max):F2}]");
+
+            // Show coarse histogram (top 5 buckets)
+            var top5 = Enumerable.Range(0, 256)
+                .OrderByDescending(i => histogram[i])
+                .Take(5)
+                .Where(i => histogram[i] > 0);
+            Console.Write("    Top raw ranges:");
+            foreach (int b in top5)
+                Console.Write($" [{b * 256}..{b * 256 + 255}]={histogram[b]}");
+            Console.WriteLine();
+        }
+
+        private static byte[] DecompressZlib(byte[] data, long offset, uint compressedSize, int expectedSize)
+        {
+            try
+            {
+                using var ms = new System.IO.MemoryStream(data, (int)offset, (int)compressedSize);
+                using var zlib = new System.IO.Compression.ZLibStream(ms, System.IO.Compression.CompressionMode.Decompress);
+                var result = new byte[expectedSize];
+                int totalRead = 0;
+                while (totalRead < expectedSize)
+                {
+                    int bytesRead = zlib.Read(result, totalRead, expectedSize - totalRead);
+                    if (bytesRead == 0) break;
+                    totalRead += bytesRead;
+                }
+                return result;
+            }
+            catch { return null; }
+        }
+
+        private static uint ReadUInt32(byte[] data, long offset)
+        {
+            return (uint)(data[offset] | (data[offset + 1] << 8) | (data[offset + 2] << 16) | (data[offset + 3] << 24));
+        }
+
+        private static int ReadInt32(byte[] data, long offset) => (int)ReadUInt32(data, offset);
+
+        private static float ReadFloat(byte[] data, long offset) => BitConverter.ToSingle(data, (int)offset);
+
+        private static int CeilDiv(int a, int b) => (a + b - 1) / b;
+    }
+}

--- a/gen_btd_test.cs
+++ b/gen_btd_test.cs
@@ -1,0 +1,356 @@
+using Retrograde.Utils;
+using System;
+using System.Linq;
+
+namespace FrankyCLI
+{
+    public class gen_btd_test
+    {
+        public static int Generate(string[] args)
+        {
+            string btdPath = @"C:\Program Files (x86)\Steam\steamapps\common\Starfield\Data\terrain\oebb008world.btd";
+
+            if (args.Length >= 6 && !string.IsNullOrWhiteSpace(args[5]))
+                btdPath = args[5];
+
+            Console.WriteLine($"=== BTD Terrain Reader Test ===");
+            Console.WriteLine($"File: {btdPath}");
+            Console.WriteLine();
+
+            if (!System.IO.File.Exists(btdPath))
+            {
+                Console.WriteLine($"ERROR: BTD file not found at '{btdPath}'");
+                return 1;
+            }
+
+            int passed = 0;
+            int failed = 0;
+
+            // --- Test 1: Load file ---
+            BtdTerrainReader reader;
+            try
+            {
+                reader = new BtdTerrainReader(btdPath);
+                Pass(ref passed, "Load BTD file");
+            }
+            catch (Exception ex)
+            {
+                Fail(ref failed, "Load BTD file", ex.Message);
+                return 1;
+            }
+
+            // --- Test 2: Header sanity checks ---
+            Console.WriteLine("--- Header Values ---");
+            Console.WriteLine($"  IsStarfield:    {reader.IsStarfield}");
+            Console.WriteLine($"  CellMinX:       {reader.CellMinX}");
+            Console.WriteLine($"  CellMinY:       {reader.CellMinY}");
+            Console.WriteLine($"  CellMaxX:       {reader.CellMaxX}");
+            Console.WriteLine($"  CellMaxY:       {reader.CellMaxY}");
+            Console.WriteLine($"  CellCountX:     {reader.CellCountX}");
+            Console.WriteLine($"  CellCountY:     {reader.CellCountY}");
+            Console.WriteLine($"  WorldHeightMin: {reader.WorldHeightMin}");
+            Console.WriteLine($"  WorldHeightMax: {reader.WorldHeightMax}");
+            Console.WriteLine();
+
+            Check(ref passed, ref failed, "IsStarfield is true",
+                reader.IsStarfield, "Expected Starfield BTD");
+
+            Check(ref passed, ref failed, "CellCountX > 0",
+                reader.CellCountX > 0, $"Got {reader.CellCountX}");
+
+            Check(ref passed, ref failed, "CellCountY > 0",
+                reader.CellCountY > 0, $"Got {reader.CellCountY}");
+
+            Check(ref passed, ref failed, "WorldHeightMax > WorldHeightMin",
+                reader.WorldHeightMax > reader.WorldHeightMin,
+                $"Min={reader.WorldHeightMin}, Max={reader.WorldHeightMax}");
+
+            // --- Test 3: Read a cell height map at LOD0 ---
+            int testCellX = reader.CellMinX;
+            int testCellY = reader.CellMinY;
+            Console.WriteLine($"--- Cell Height Map LOD0 at ({testCellX}, {testCellY}) ---");
+
+            try
+            {
+                var buf = new ushort[128 * 128];
+                reader.GetCellHeightMap(buf, testCellX, testCellY, 0);
+
+                ushort min = buf.Min();
+                ushort max = buf.Max();
+                double avg = buf.Average(v => (double)v);
+                bool hasNonZero = buf.Any(v => v != 0);
+
+                Console.WriteLine($"  Raw min: {min}, max: {max}, avg: {avg:F1}");
+                Console.WriteLine($"  Height min: {reader.RawToHeight(min):F2}, max: {reader.RawToHeight(max):F2}");
+
+                Pass(ref passed, "GetCellHeightMap LOD0 succeeded");
+                Check(ref passed, ref failed, "Height map has non-zero values",
+                    hasNonZero, "All values were zero");
+                Check(ref passed, ref failed, "Height map max > min",
+                    max > min, $"min={min}, max={max}");
+            }
+            catch (Exception ex)
+            {
+                Fail(ref failed, "GetCellHeightMap LOD0", ex.Message);
+            }
+
+            // --- Test 4: Read center cell ---
+            int centerX = (reader.CellMinX + reader.CellMaxX) / 2;
+            int centerY = (reader.CellMinY + reader.CellMaxY) / 2;
+            Console.WriteLine($"--- Center Cell ({centerX}, {centerY}) ---");
+
+            try
+            {
+                var buf = new ushort[128 * 128];
+                reader.GetCellHeightMap(buf, centerX, centerY, 0);
+
+                ushort min = buf.Min();
+                ushort max = buf.Max();
+                Console.WriteLine($"  Raw min: {min}, max: {max}");
+                Console.WriteLine($"  Height min: {reader.RawToHeight(min):F2}, max: {reader.RawToHeight(max):F2}");
+
+                Pass(ref passed, "GetCellHeightMap center cell");
+            }
+            catch (Exception ex)
+            {
+                Fail(ref failed, "GetCellHeightMap center cell", ex.Message);
+            }
+
+            // --- Test 5: LOD levels ---
+            for (int lod = 1; lod <= 3; lod++)
+            {
+                int res = 128 >> lod;
+                try
+                {
+                    var buf = new ushort[res * res];
+                    reader.GetCellHeightMap(buf, testCellX, testCellY, lod);
+
+                    bool hasNonZero = buf.Any(v => v != 0);
+                    Console.WriteLine($"  LOD{lod} ({res}x{res}): min={buf.Min()}, max={buf.Max()}, nonZero={hasNonZero}");
+
+                    Pass(ref passed, $"GetCellHeightMap LOD{lod}");
+                }
+                catch (Exception ex)
+                {
+                    Fail(ref failed, $"GetCellHeightMap LOD{lod}", ex.Message);
+                }
+            }
+
+            // --- Test 6: GetHeight single vertex ---
+            Console.WriteLine($"--- GetHeight single vertex ---");
+            try
+            {
+                float h00 = reader.GetHeight(testCellX, testCellY, 0, 0);
+                float h64 = reader.GetHeight(testCellX, testCellY, 64, 64);
+                float h127 = reader.GetHeight(testCellX, testCellY, 127, 127);
+
+                Console.WriteLine($"  (0,0)={h00:F2}  (64,64)={h64:F2}  (127,127)={h127:F2}");
+
+                Check(ref passed, ref failed, "GetHeight returns finite values",
+                    float.IsFinite(h00) && float.IsFinite(h64) && float.IsFinite(h127),
+                    "Non-finite height value");
+
+                Check(ref passed, ref failed, "GetHeight within world bounds",
+                    h00 >= reader.WorldHeightMin && h00 <= reader.WorldHeightMax,
+                    $"Height {h00} outside [{reader.WorldHeightMin}, {reader.WorldHeightMax}]");
+
+                Pass(ref passed, "GetHeight single vertex");
+            }
+            catch (Exception ex)
+            {
+                Fail(ref failed, "GetHeight single vertex", ex.Message);
+            }
+
+            // --- Test 7: SampleHeightAtWorld ---
+            Console.WriteLine($"--- SampleHeightAtWorld ---");
+            try
+            {
+                float worldX = centerX * 4096f + 2048f;
+                float worldY = centerY * 4096f + 2048f;
+                float h = reader.SampleHeightAtWorld(worldX, worldY);
+
+                Console.WriteLine($"  World ({worldX:F0}, {worldY:F0}) -> height {h:F2}");
+
+                Check(ref passed, ref failed, "SampleHeightAtWorld returns finite",
+                    float.IsFinite(h), $"Got {h}");
+
+                Check(ref passed, ref failed, "SampleHeightAtWorld within world bounds",
+                    h >= reader.WorldHeightMin && h <= reader.WorldHeightMax,
+                    $"Height {h} outside [{reader.WorldHeightMin}, {reader.WorldHeightMax}]");
+
+                Pass(ref passed, "SampleHeightAtWorld");
+            }
+            catch (Exception ex)
+            {
+                Fail(ref failed, "SampleHeightAtWorld", ex.Message);
+            }
+
+            // --- Test 8: RawToHeight boundary values ---
+            Console.WriteLine($"--- RawToHeight boundary values ---");
+            {
+                float hMin = reader.RawToHeight(0);
+                float hMax = reader.RawToHeight(65535);
+                float hMid = reader.RawToHeight(32768);
+
+                Console.WriteLine($"  Raw 0     -> {hMin:F2} (expected ~{reader.WorldHeightMin:F2})");
+                Console.WriteLine($"  Raw 65535 -> {hMax:F2} (expected ~{reader.WorldHeightMax:F2})");
+                Console.WriteLine($"  Raw 32768 -> {hMid:F2}");
+
+                Check(ref passed, ref failed, "RawToHeight(0) == WorldHeightMin",
+                    Math.Abs(hMin - reader.WorldHeightMin) < 0.01f,
+                    $"Got {hMin}, expected {reader.WorldHeightMin}");
+
+                Check(ref passed, ref failed, "RawToHeight(65535) ~= WorldHeightMax",
+                    Math.Abs(hMax - reader.WorldHeightMax) < 1.0f,
+                    $"Got {hMax}, expected {reader.WorldHeightMax}");
+            }
+
+            // --- Test 9: Out-of-range cell throws ---
+            Console.WriteLine($"--- Out-of-range checks ---");
+            try
+            {
+                var buf = new ushort[128 * 128];
+                reader.GetCellHeightMap(buf, reader.CellMaxX + 100, reader.CellMaxY + 100, 0);
+                Fail(ref failed, "Out-of-range cell throws", "No exception was thrown");
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                Pass(ref passed, "Out-of-range cell throws ArgumentOutOfRangeException");
+            }
+            catch (Exception ex)
+            {
+                Fail(ref failed, "Out-of-range cell throws", $"Wrong exception type: {ex.GetType().Name}");
+            }
+
+            // --- Test 10: HeightToRaw round-trip ---
+            Console.WriteLine($"--- HeightToRaw round-trip ---");
+            {
+                ushort raw1 = 0;
+                ushort raw2 = 32768;
+                ushort raw3 = 65535;
+                Check(ref passed, ref failed, "HeightToRaw(RawToHeight(0)) == 0",
+                    reader.HeightToRaw(reader.RawToHeight(raw1)) == raw1,
+                    $"Got {reader.HeightToRaw(reader.RawToHeight(raw1))}");
+                Check(ref passed, ref failed, "HeightToRaw(RawToHeight(32768)) == 32768",
+                    reader.HeightToRaw(reader.RawToHeight(raw2)) == raw2,
+                    $"Got {reader.HeightToRaw(reader.RawToHeight(raw2))}");
+                Check(ref passed, ref failed, "HeightToRaw(RawToHeight(65535)) == 65535",
+                    reader.HeightToRaw(reader.RawToHeight(raw3)) == raw3,
+                    $"Got {reader.HeightToRaw(reader.RawToHeight(raw3))}");
+            }
+
+            // --- Test 11: SetHeight + read back ---
+            Console.WriteLine($"--- SetHeight + read back ---");
+            try
+            {
+                ushort origVal = (ushort)(reader.HeightToRaw(reader.GetHeight(testCellX, testCellY, 0, 0)));
+                ushort newVal = (ushort)(origVal == 12345 ? 54321 : 12345);
+
+                reader.SetHeight(testCellX, testCellY, 0, 0, newVal);
+                float readBack = reader.GetHeight(testCellX, testCellY, 0, 0);
+                ushort readBackRaw = reader.HeightToRaw(readBack);
+
+                Check(ref passed, ref failed, "SetHeight value persists in memory",
+                    readBackRaw == newVal,
+                    $"Expected {newVal}, got {readBackRaw}");
+
+                // Restore original
+                reader.SetHeight(testCellX, testCellY, 0, 0, origVal);
+                Pass(ref passed, "SetHeight + read back");
+            }
+            catch (Exception ex)
+            {
+                Fail(ref failed, "SetHeight + read back", ex.Message);
+            }
+
+            // --- Test 12: Save + reload round-trip ---
+            Console.WriteLine($"--- Save + reload round-trip ---");
+            try
+            {
+                string tempPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "btd_test_output.btd");
+
+                // Read original cell data
+                var origBuf = new ushort[128 * 128];
+                reader.GetCellHeightMap(origBuf, testCellX, testCellY, 0);
+                ushort origCorner = origBuf[0];
+
+                // Modify a single vertex
+                ushort modifiedVal = (ushort)(origCorner == 11111 ? 22222 : 11111);
+                reader.SetHeight(testCellX, testCellY, 0, 0, modifiedVal);
+
+                // Also read an unmodified cell for comparison
+                var unmodBuf = new ushort[128 * 128];
+                reader.GetCellHeightMap(unmodBuf, centerX, centerY, 0);
+
+                // Save
+                reader.Save(tempPath);
+                Pass(ref passed, "Save to temp file");
+
+                // Reload
+                var reader2 = new BtdTerrainReader(tempPath);
+                Pass(ref passed, "Reload saved file");
+
+                // Check header matches
+                Check(ref passed, ref failed, "Saved header: CellCountX matches",
+                    reader2.CellCountX == reader.CellCountX,
+                    $"Expected {reader.CellCountX}, got {reader2.CellCountX}");
+                Check(ref passed, ref failed, "Saved header: WorldHeightMin matches",
+                    Math.Abs(reader2.WorldHeightMin - reader.WorldHeightMin) < 0.01f,
+                    $"Expected {reader.WorldHeightMin}, got {reader2.WorldHeightMin}");
+
+                // Check modified cell
+                float reloadedHeight = reader2.GetHeight(testCellX, testCellY, 0, 0);
+                ushort reloadedRaw = reader2.HeightToRaw(reloadedHeight);
+                Check(ref passed, ref failed, "Modified vertex persists after save/reload",
+                    reloadedRaw == modifiedVal,
+                    $"Expected {modifiedVal}, got {reloadedRaw}");
+
+                // Check unmodified cell is intact
+                var reloadUnmod = new ushort[128 * 128];
+                reader2.GetCellHeightMap(reloadUnmod, centerX, centerY, 0);
+                bool unmodMatch = true;
+                for (int i = 0; i < unmodBuf.Length; i++)
+                {
+                    if (unmodBuf[i] != reloadUnmod[i]) { unmodMatch = false; break; }
+                }
+                Check(ref passed, ref failed, "Unmodified cell unchanged after save/reload",
+                    unmodMatch, "Cell data differs");
+
+                // Restore original and clean up
+                reader.SetHeight(testCellX, testCellY, 0, 0, origCorner);
+                try { System.IO.File.Delete(tempPath); } catch { }
+
+                Console.WriteLine($"  Temp file: {tempPath}");
+            }
+            catch (Exception ex)
+            {
+                Fail(ref failed, "Save + reload round-trip", ex.Message);
+            }
+
+            // --- Summary ---
+            Console.WriteLine();
+            Console.WriteLine($"=== Results: {passed} passed, {failed} failed ===");
+            return failed > 0 ? 1 : 0;
+        }
+
+        private static void Pass(ref int passed, string name)
+        {
+            passed++;
+            Console.WriteLine($"  PASS: {name}");
+        }
+
+        private static void Fail(ref int failed, string name, string reason)
+        {
+            failed++;
+            Console.WriteLine($"  FAIL: {name} - {reason}");
+        }
+
+        private static void Check(ref int passed, ref int failed, string name, bool condition, string failReason)
+        {
+            if (condition)
+                Pass(ref passed, name);
+            else
+                Fail(ref failed, name, failReason);
+        }
+    }
+}

--- a/gen_btd_test.cs
+++ b/gen_btd_test.cs
@@ -27,10 +27,10 @@ namespace FrankyCLI
             int failed = 0;
 
             // --- Test 1: Load file ---
-            BtdTerrainReader reader;
+            BtdFile reader;
             try
             {
-                reader = new BtdTerrainReader(btdPath);
+                reader = new BtdFile(btdPath);
                 Pass(ref passed, "Load BTD file");
             }
             catch (Exception ex)
@@ -287,7 +287,7 @@ namespace FrankyCLI
                 Pass(ref passed, "Save to temp file");
 
                 // Reload
-                var reader2 = new BtdTerrainReader(tempPath);
+                var reader2 = new BtdFile(tempPath);
                 Pass(ref passed, "Reload saved file");
 
                 // Check header matches

--- a/info_btd.bat
+++ b/info_btd.bat
@@ -1,0 +1,3 @@
+@echo off
+C:\Git\FrankyCLI\bin\Debug\net6.0\FrankyCLI.exe dummy gen_btd_info dummy dummy dummy
+pause

--- a/info_btd_all.bat
+++ b/info_btd_all.bat
@@ -1,0 +1,3 @@
+@echo off
+C:\Git\FrankyCLI\bin\Debug\net6.0\FrankyCLI.exe dummy gen_btd_info dummy dummy dummy "C:\Program Files (x86)\Steam\steamapps\common\Starfield\Data\terrain"
+pause

--- a/test_btd.bat
+++ b/test_btd.bat
@@ -1,0 +1,3 @@
+@echo off
+C:\Git\FrankyCLI\bin\Debug\net6.0\FrankyCLI.exe dummy gen_btd_test dummy dummy dummy
+pause


### PR DESCRIPTION
Implements BtdTerrainReader in Retrograde.Utils that parses Bethesda
Terrain Data (.btd) files based on the fo76utils reverse engineering.

Key features:
- Parses the BTDB header (version 5/6) with Starfield auto-detection
- Handles Starfield's zeroed cell boundaries and 8x height scale
- Decompresses zlib-compressed terrain blocks at LOD levels 0-3
- 8x8 cell tile caching for efficient repeated access
- Per-cell 128x128 vertex height data extraction
- Bilinear-interpolated world-space height sampling via SampleHeightAtWorld()
- Support for both Starfield and Fallout 76 block layouts

https://claude.ai/code/session_01L8i3KhXJJRZoswXwvSCcKs