### PR TITLE
Add gen_harvester: Starfield furniture prefab harvester

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -102,6 +102,10 @@ switch (mode)
     case "gen_roompackin":
         return gen_roompackin.Generate(args);
 
+    case "gen_harvester":
+        // gen_harvester <baseForm> [radius] [maxVariants] [outputMod]
+        return gen_harvester.Generate(args);
+
     // Legacy ship generators (keep original arg layout)
     case "struct":
     case "flip":
@@ -159,7 +163,14 @@ static void PrintHelp()
     Console.WriteLine("                     Defaults: modname=RG_CoordTest");
     Console.WriteLine();
     Console.WriteLine("  gen_roompackin");
-Console.WriteLine("                     Generate SCI hallway PackIn variants into generated_templates.esm.");
+    Console.WriteLine("                     Generate SCI hallway PackIn variants into generated_templates.esm.");
+    Console.WriteLine();
+    Console.WriteLine("  gen_harvester   <baseForm> [radius] [maxVariants] [outputMod]");
+    Console.WriteLine("                     Scan Starfield interior cells for instances of a base form");
+    Console.WriteLine("                     (furniture, static, etc.) and emit PackIn prefabs of each");
+    Console.WriteLine("                     found cluster — anchor at (0,0,0) + nearby Starfield objects.");
+    Console.WriteLine("                     baseForm: EditorID partial match or 0xFormID");
+    Console.WriteLine("                     Defaults: radius=150, maxVariants=50, outputMod=harvested_prefabs");
 Console.WriteLine();
 Console.WriteLine("BTD terrain tools:");
     Console.WriteLine("  gen_btd_info    [btdpath] [--all]   Dump BTD file structure.");

--- a/Retrograde.Library/FurnitureHarvester/FurnitureHarvester.cs
+++ b/Retrograde.Library/FurnitureHarvester/FurnitureHarvester.cs
@@ -1,0 +1,339 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Starfield;
+using Noggog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Retrograde.FurnitureHarvester;
+
+/// <summary>
+/// Scans all interior cells in Starfield.esm for instances of a target base form
+/// (e.g. a specific furniture or static), then creates PackIn prefabs of each instance
+/// together with every nearby object within the configured radius.
+///
+/// The target form is placed at the origin (0,0,0) with no rotation. All other objects
+/// in the group are translated and yaw-rotated to match, preserving their relative layout.
+///
+/// Only objects whose Base links to Starfield.esm are included to avoid dependencies on
+/// DLC or other mods.
+///
+/// Usage:
+///   var h = new FurnitureHarvester(outputMod, sfModKey);
+///   int count = h.Harvest(starfieldGetter, targetFormKey, "sanitisedLabel", radius: 150f, maxVariants: 50);
+/// </summary>
+public class FurnitureHarvester
+{
+    // PrefabPackinPivotDummy — always first Temporary entry in every PackIn cell.
+    private const uint IdPivot = 0x03F808;
+
+    private readonly StarfieldMod _targetMod;
+    private readonly ModKey _sfModKey;
+
+    // Running counter for unique EditorID generation.
+    private int _variantSeq = 1;
+
+    public FurnitureHarvester(StarfieldMod targetMod, ModKey sfModKey)
+    {
+        _targetMod = targetMod;
+        _sfModKey  = sfModKey;
+    }
+
+    // ── Public entry point ────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Scans all interior cells in <paramref name="starfield"/> for placed instances of
+    /// <paramref name="targetFormKey"/> and harvests up to <paramref name="maxVariants"/>
+    /// PackIn prefabs into the target mod.
+    /// </summary>
+    /// <param name="starfield">The mod to scan (typically Starfield.esm).</param>
+    /// <param name="targetFormKey">FormKey of the furniture/static to use as the anchor.</param>
+    /// <param name="baseLabel">Short label used in generated EditorIDs (already sanitised).</param>
+    /// <param name="radius">Capture radius in game units around each found instance.</param>
+    /// <param name="maxVariants">Upper bound on the number of prefabs to create.</param>
+    /// <returns>Number of prefabs created.</returns>
+    public int Harvest(
+        IStarfieldModGetter starfield,
+        FormKey              targetFormKey,
+        string               baseLabel,
+        float                radius,
+        int                  maxVariants)
+    {
+        int count = 0;
+
+        // ── Interior cells ────────────────────────────────────────────────────
+        foreach (var block in starfield.Cells)
+        {
+            foreach (var subBlock in block.SubBlocks)
+            {
+                foreach (var cell in subBlock.Cells)
+                {
+                    if (count >= maxVariants) goto Done;
+                    count += HarvestCell(cell, targetFormKey, baseLabel, radius, maxVariants - count);
+                }
+            }
+        }
+
+        Done:
+        return count;
+    }
+
+    // ── Per-cell scan ─────────────────────────────────────────────────────────
+
+    private int HarvestCell(
+        ICellGetter cell,
+        FormKey     targetFormKey,
+        string      baseLabel,
+        float       radius,
+        int         remaining)
+    {
+        // Merge Persistent + Temporary into one pool of placed objects.
+        var allObjects = cell.Persistent
+            .Concat(cell.Temporary)
+            .OfType<IPlacedObjectGetter>()
+            .ToList();
+
+        // Find every instance of the target form in this cell.
+        var anchors = allObjects
+            .Where(o => o.Base.FormKey == targetFormKey)
+            .ToList();
+
+        if (anchors.Count == 0) return 0;
+
+        int created = 0;
+
+        foreach (var anchor in anchors)
+        {
+            if (created >= remaining) break;
+
+            // Collect all Starfield.esm objects within the radius.
+            var group = allObjects
+                .Where(o => o.Base.FormKey.ModKey.Name == "Starfield")
+                .Where(o => Distance(o.Position, anchor.Position) <= radius)
+                .ToList();
+
+            // Skip trivial groups — anchor alone is not interesting.
+            if (group.Count <= 1)
+            {
+                Console.WriteLine($"  [skip] isolated anchor in {cell.EditorID ?? cell.FormKey.ToString()} ({group.Count} object)");
+                continue;
+            }
+
+            string variantId = $"rg_harv_{baseLabel}_{_variantSeq:D3}";
+            _variantSeq++;
+
+            CreatePrefab(variantId, anchor, group);
+            created++;
+
+            string cellLabel = cell.EditorID ?? cell.FormKey.ToString();
+            Console.WriteLine($"  [{_variantSeq - 1:D3}] {variantId} — {group.Count} objects from {cellLabel}");
+        }
+
+        return created;
+    }
+
+    // ── Prefab creation ───────────────────────────────────────────────────────
+
+    private void CreatePrefab(
+        string                  editorId,
+        IPlacedObjectGetter     anchor,
+        List<IPlacedObjectGetter> group)
+    {
+        var cell = CreateCell(editorId);
+
+        // Pivot dummy — always the first Temporary entry.
+        AddTemp(cell, IdPivot, 0f, 0f, 0f);
+
+        // Compute the inverse transform: translate by -anchorPos, rotate by -anchorYaw.
+        var   anchorPos = anchor.Position ?? new P3Float(0, 0, 0);
+        float anchorYaw = anchor.Rotation?.Z ?? 0f;
+        float cos       = MathF.Cos(-anchorYaw);
+        float sin       = MathF.Sin(-anchorYaw);
+
+        // Track extents for ObjectBounds.
+        float minX = float.MaxValue, minY = float.MaxValue, minZ = float.MaxValue;
+        float maxX = float.MinValue, maxY = float.MinValue, maxZ = float.MinValue;
+
+        foreach (var obj in group)
+        {
+            var pos = obj.Position ?? new P3Float(0, 0, 0);
+
+            // Translate relative to anchor.
+            float dx = pos.X - anchorPos.X;
+            float dy = pos.Y - anchorPos.Y;
+            float dz = pos.Z - anchorPos.Z;
+
+            // Rotate around Z by -anchorYaw.
+            float rx = cos * dx - sin * dy;
+            float ry = sin * dx + cos * dy;
+
+            // Adjust rotation: subtract anchor yaw from the object's yaw.
+            float relYaw = (obj.Rotation?.Z ?? 0f) - anchorYaw;
+            var   relRot = new P3Float(
+                obj.Rotation?.X ?? 0f,
+                obj.Rotation?.Y ?? 0f,
+                relYaw);
+
+            // For the anchor itself, force to exact origin with zero rotation.
+            if (obj.FormKey == anchor.FormKey)
+            {
+                rx     = 0f;
+                ry     = 0f;
+                dz     = 0f;
+                relRot = new P3Float(0f, 0f, 0f);
+            }
+
+            AddTempFromGetter(cell, obj, rx, ry, dz, relRot);
+
+            minX = MathF.Min(minX, rx);
+            minY = MathF.Min(minY, ry);
+            minZ = MathF.Min(minZ, dz);
+            maxX = MathF.Max(maxX, rx);
+            maxY = MathF.Max(maxY, ry);
+            maxZ = MathF.Max(maxZ, dz);
+        }
+
+        // Add a small margin to the bounds.
+        const float Pad = 20f;
+
+        var packin = new PackIn(_targetMod)
+        {
+            EditorID            = editorId,
+            MajorRecordFlagsRaw = 512, // Prefab flag
+            ObjectBounds        = new ObjectBounds
+            {
+                First  = new P3Int16(
+                    (short)MathF.Floor(minX - Pad),
+                    (short)MathF.Floor(minY - Pad),
+                    (short)MathF.Floor(minZ - Pad)),
+                Second = new P3Int16(
+                    (short)MathF.Ceiling(maxX + Pad),
+                    (short)MathF.Ceiling(maxY + Pad),
+                    (short)MathF.Ceiling(maxZ + Pad + 50f)),
+            },
+        };
+        packin.Cell = cell.ToNullableLink<ICellGetter>();
+        _targetMod.PackIns.Add(packin);
+    }
+
+    // ── Cell infrastructure ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// Creates a new interior Cell and inserts it into the correct CellBlock / CellSubBlock
+    /// hierarchy in the target mod. Follows the same block/subblock routing as
+    /// SciHallwayGenerator and SciRoomGenerator.
+    /// </summary>
+    private Cell CreateCell(string editorId)
+    {
+        var cell = new Cell(_targetMod)
+        {
+            EditorID   = editorId + "_cell",
+            Flags      = Cell.Flag.IsInteriorCell,
+            Temporary  = new ExtendedList<IPlaced>(),
+            Persistent = new ExtendedList<IPlaced>(),
+        };
+
+        int blockNum    = (int)(cell.FormKey.ID % 10);
+        int subBlockNum = (int)((cell.FormKey.ID / 10) % 10);
+
+        // Find or create CellBlock.
+        CellBlock? cellBlock = null;
+        foreach (var b in _targetMod.Cells)
+            if (b.BlockNumber == blockNum) { cellBlock = b; break; }
+
+        if (cellBlock == null)
+        {
+            cellBlock = new CellBlock
+            {
+                BlockNumber = blockNum,
+                GroupType   = GroupTypeEnum.InteriorCellBlock,
+                SubBlocks   = new ExtendedList<CellSubBlock>(),
+            };
+            _targetMod.Cells.Add(cellBlock);
+        }
+
+        // Find or create CellSubBlock.
+        CellSubBlock? subBlock = null;
+        foreach (var sb in cellBlock.SubBlocks)
+            if (sb.BlockNumber == subBlockNum) { subBlock = sb; break; }
+
+        if (subBlock == null)
+        {
+            subBlock = new CellSubBlock
+            {
+                BlockNumber = subBlockNum,
+                GroupType   = GroupTypeEnum.InteriorCellSubBlock,
+                Cells       = new ExtendedList<Cell>(),
+            };
+            cellBlock.SubBlocks.Add(subBlock);
+        }
+
+        subBlock.Cells.Add(cell);
+        return cell;
+    }
+
+    // ── Placed object helpers ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// Clones a getter-typed PlacedObject into the target mod's cell at the given
+    /// transformed position/rotation. Copies the most important visual properties
+    /// (scale, lighting, lock) while assigning a fresh FormKey.
+    /// </summary>
+    private void AddTempFromGetter(
+        Cell                cell,
+        IPlacedObjectGetter source,
+        float x, float y, float z,
+        P3Float             rotation)
+    {
+        var placed = new PlacedObject(_targetMod)
+        {
+            Count    = source.Count,
+            Base     = source.Base.FormKey.ToLink<IPlaceableObjectGetter>(),
+            Position = new P3Float(x, y, z),
+            Rotation = rotation,
+            Scale    = source.Scale,
+        };
+
+        // Preserve lighting and lock state.
+        if (source.Lighting != null)
+            placed.Lighting = source.Lighting.DeepCopy();
+        if (source.Lock != null)
+            placed.Lock = source.Lock.DeepCopy();
+
+        // Preserve layered material swaps (e.g. blood/damage decals).
+        if (source.LayeredMaterialSwaps != null)
+            placed.LayeredMaterialSwaps = source.LayeredMaterialSwaps
+                .Select(s => s.DeepCopy())
+                .ToExtendedList();
+
+        // Preserve enable-parent link so toggled props stay wired up.
+        if (source.EnableParent != null)
+            placed.EnableParent = source.EnableParent.DeepCopy();
+
+        cell.Temporary.Add(placed);
+    }
+
+    /// <summary>Adds a simple Starfield.esm static to a cell's Temporary list.</summary>
+    private void AddTemp(Cell cell, uint formId, float x, float y, float z, P3Float? rotation = null)
+    {
+        var po = new PlacedObject(_targetMod)
+        {
+            Base     = new FormKey(_sfModKey, formId).ToLink<IPlaceableObjectGetter>(),
+            Position = new P3Float(x, y, z),
+            Rotation = rotation ?? new P3Float(0f, 0f, 0f),
+        };
+        cell.Temporary.Add(po);
+    }
+
+    // ── Utilities ─────────────────────────────────────────────────────────────
+
+    private static float Distance(P3Float? a, P3Float? b)
+    {
+        if (a == null || b == null) return float.MaxValue;
+        float dx = a.X - b.X;
+        float dy = a.Y - b.Y;
+        float dz = a.Z - b.Z;
+        return MathF.Sqrt(dx * dx + dy * dy + dz * dz);
+    }
+}

--- a/gen_harvester.bat
+++ b/gen_harvester.bat
@@ -1,0 +1,17 @@
+@echo off
+:: gen_harvester.bat — Starfield Furniture Prefab Harvester
+::
+:: Usage: gen_harvester.bat <baseForm> [radius] [maxVariants] [outputMod]
+::
+::   baseForm     EditorID (partial, case-insensitive) or 0xFormID
+::   radius       Capture radius in game units (default: 150)
+::   maxVariants  Max PackIn prefabs to generate (default: 50)
+::   outputMod    Output ESM name without extension (default: harvested_prefabs)
+::
+:: Examples:
+::   gen_harvester.bat MedBed
+::   gen_harvester.bat ChairOffice 120 20
+::   gen_harvester.bat 0x00012345 200 10 my_prefabs
+
+dotnet build || goto :eof
+bin\Debug\net8.0\FrankyCLI.exe gen_harvester %*

--- a/gen_harvester.cs
+++ b/gen_harvester.cs
@@ -1,0 +1,199 @@
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Environments;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Starfield;
+using Retrograde.FurnitureHarvester;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace FrankyCLI;
+
+/// <summary>
+/// Scans all interior cells in Starfield.esm for instances of a specified base form
+/// (furniture, static, activator, etc.) and emits a PackIn prefab for each found
+/// cluster — the anchor at (0,0,0) with no rotation plus every Starfield.esm object
+/// within a configurable capture radius.
+///
+/// Usage:
+///   gen_harvester &lt;baseForm&gt; [radius] [maxVariants] [outputMod]
+///
+///   baseForm     EditorID (partial, case-insensitive) or 0xFormID of the anchor object.
+///                Searches Furniture, Statics, and Activators — first match wins.
+///   radius       Capture sphere radius in game units.  Default: 150
+///   maxVariants  Maximum number of prefabs to generate. Default: 50
+///   outputMod    Output .esm name (without extension).  Default: harvested_prefabs
+///
+/// Output:
+///   {DataFolder}/{outputMod}.esm  — PackIn records + interior cells, no template-mod deps.
+///
+/// Examples:
+///   gen_harvester MedBed
+///   gen_harvester ChairOffice 120 20
+///   gen_harvester 0x00012345 200 10 my_prefabs
+/// </summary>
+public class gen_harvester
+{
+    private const string DefaultOutputMod = "harvested_prefabs";
+    private const float  DefaultRadius    = 150f;
+    private const int    DefaultMax       = 50;
+
+    public static int Generate(string[] args)
+    {
+        Console.WriteLine("=== gen_harvester: Starfield Furniture Prefab Harvester ===");
+        Console.WriteLine();
+
+        if (args.Length < 2)
+        {
+            PrintUsage();
+            return 1;
+        }
+
+        string baseFormArg = args[1];
+        float  radius      = TryParseFloat(args, 2, DefaultRadius);
+        int    maxVariants = TryParseInt  (args, 3, DefaultMax);
+        string outputName  = GetArg       (args, 4, DefaultOutputMod);
+
+        Console.WriteLine($"Base form:  {baseFormArg}");
+        Console.WriteLine($"Radius:     {radius} units");
+        Console.WriteLine($"Max:        {maxVariants} variants");
+        Console.WriteLine($"Output:     {outputName}.esm");
+        Console.WriteLine();
+
+        using var env = GameEnvironment.Typical
+            .Builder<IStarfieldMod, IStarfieldModGetter>(GameRelease.Starfield)
+            .Build();
+
+        gen_quest_main.BuildReadParams(env.LoadOrder);
+
+        var sfModKey  = env.LoadOrder[0].ModKey;
+        var starfield = env.LoadOrder[0].Mod;
+
+        if (starfield == null)
+        {
+            Console.WriteLine("ERROR: Could not load Starfield.esm");
+            return 1;
+        }
+
+        // ── Resolve the target form ────────────────────────────────────────────
+        FormKey targetFormKey;
+        string  baseEditorId;
+
+        if (baseFormArg.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+        {
+            if (!uint.TryParse(baseFormArg[2..],
+                    System.Globalization.NumberStyles.HexNumber, null, out uint rawId))
+            {
+                Console.WriteLine($"ERROR: Invalid FormID '{baseFormArg}' — expected 0xHHHHHH");
+                return 1;
+            }
+
+            targetFormKey = new FormKey(sfModKey, rawId);
+
+            // Best-effort EditorID lookup for label generation.
+            baseEditorId = starfield.EnumerateMajorRecords()
+                .FirstOrDefault(r => r.FormKey == targetFormKey)
+                ?.EditorID
+                ?? $"form_{rawId:X6}";
+
+            Console.WriteLine($"Resolved: [{targetFormKey}] → {baseEditorId}");
+        }
+        else
+        {
+            // EditorID partial-match search (case-insensitive).
+            // Priority order: Furniture → Statics → Activators → any record.
+            IMajorRecordGetter? match =
+                (IMajorRecordGetter?)starfield.Furniture
+                    .FirstOrDefault(f => f.EditorID?.Contains(
+                        baseFormArg, StringComparison.OrdinalIgnoreCase) == true)
+                ?? starfield.Statics
+                    .FirstOrDefault(s => s.EditorID?.Contains(
+                        baseFormArg, StringComparison.OrdinalIgnoreCase) == true)
+                ?? starfield.Activators
+                    .FirstOrDefault(a => a.EditorID?.Contains(
+                        baseFormArg, StringComparison.OrdinalIgnoreCase) == true)
+                ?? starfield.EnumerateMajorRecords()
+                    .FirstOrDefault(r => r.EditorID?.Contains(
+                        baseFormArg, StringComparison.OrdinalIgnoreCase) == true);
+
+            if (match == null)
+            {
+                Console.WriteLine($"ERROR: No form found with EditorID containing '{baseFormArg}'");
+                Console.WriteLine("Tip: use gen_inspect to look up the FormID first.");
+                return 1;
+            }
+
+            targetFormKey = match.FormKey;
+            baseEditorId  = match.EditorID ?? baseFormArg;
+            Console.WriteLine($"Resolved: {match.EditorID} [{targetFormKey}]");
+        }
+
+        Console.WriteLine();
+
+        // ── Sanitise label for EditorID use ───────────────────────────────────
+        string safeLabel = new string(
+            baseEditorId.Select(c => char.IsLetterOrDigit(c) ? c : '_').ToArray()).Trim('_');
+        if (safeLabel.Length > 24)
+            safeLabel = safeLabel[..24];
+
+        // ── Create output mod ──────────────────────────────────────────────────
+        var outputModKey = new ModKey(outputName, ModType.Master);
+        var outputMod    = new StarfieldMod(outputModKey, StarfieldRelease.Starfield);
+
+        // ── Run harvester ──────────────────────────────────────────────────────
+        Console.WriteLine("Scanning interior cells...");
+        Console.WriteLine();
+
+        var harvester = new FurnitureHarvester(outputMod, sfModKey);
+        int count     = harvester.Harvest(starfield, targetFormKey, safeLabel, radius, maxVariants);
+
+        Console.WriteLine();
+        Console.WriteLine($"Variants harvested: {count}");
+
+        if (count == 0)
+        {
+            Console.WriteLine("Nothing to write — no qualifying clusters found.");
+            Console.WriteLine("Try: increasing radius, checking the EditorID, or using gen_inspect to verify placement cells.");
+            return 0;
+        }
+
+        // ── Write output ───────────────────────────────────────────────────────
+        string outputPath = Path.Combine(env.DataFolderPath, outputName + ".esm");
+        outputMod.WriteToBinary(outputPath, gen_quest_main.BuildWriteParams());
+
+        Console.WriteLine($"Written: {outputPath}");
+        Console.WriteLine($"PackIns: {outputMod.PackIns.Count}");
+        Console.WriteLine($"Cells:   {outputMod.Cells.Sum(b => b.SubBlocks.Sum(sb => sb.Cells.Count))}");
+
+        return 0;
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static void PrintUsage()
+    {
+        Console.WriteLine("Usage: gen_harvester <baseForm> [radius] [maxVariants] [outputMod]");
+        Console.WriteLine();
+        Console.WriteLine("  baseForm     EditorID (partial, case-insensitive) or 0xFormID");
+        Console.WriteLine("               Searches: Furniture → Statics → Activators → all records");
+        Console.WriteLine("  radius       Capture radius in game units (default: 150)");
+        Console.WriteLine("  maxVariants  Max prefabs to generate (default: 50)");
+        Console.WriteLine("  outputMod    Output ESM name, no extension (default: harvested_prefabs)");
+        Console.WriteLine();
+        Console.WriteLine("Examples:");
+        Console.WriteLine("  gen_harvester MedBed");
+        Console.WriteLine("  gen_harvester ChairOffice 120 20");
+        Console.WriteLine("  gen_harvester 0x00012345 200 10 my_prefabs");
+        Console.WriteLine();
+        Console.WriteLine("Tip: use gen_inspect to find EditorIDs or FormIDs before running.");
+    }
+
+    private static string GetArg(string[] args, int i, string def)
+        => i < args.Length && !string.IsNullOrWhiteSpace(args[i]) ? args[i] : def;
+
+    private static float TryParseFloat(string[] args, int i, float def)
+        => i < args.Length && float.TryParse(args[i], out float v) ? v : def;
+
+    private static int TryParseInt(string[] args, int i, int def)
+        => i < args.Length && int.TryParse(args[i], out int v) ? v : def;
+}

--- a/scripts/gen_harvester.sh
+++ b/scripts/gen_harvester.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# gen_harvester.sh — Starfield Furniture Prefab Harvester
+#
+# Usage: gen_harvester.sh <baseForm> [radius] [maxVariants] [outputMod]
+#
+#   baseForm     EditorID (partial, case-insensitive) or 0xFormID
+#   radius       Capture radius in game units (default: 150)
+#   maxVariants  Max PackIn prefabs to generate (default: 50)
+#   outputMod    Output ESM name without extension (default: harvested_prefabs)
+#
+# Examples:
+#   gen_harvester.sh MedBed
+#   gen_harvester.sh ChairOffice 120 20
+#   gen_harvester.sh 0x00012345 200 10 my_prefabs
+
+cd /c/Git/FrankyCLI
+dotnet run -- gen_harvester "$@" 2>&1


### PR DESCRIPTION
Scans all interior cells in Starfield.esm for placed instances of a
specified base form (furniture, static, activator, etc.) and emits a
PackIn prefab for each cluster found — the anchor form at (0,0,0) with
no rotation, plus every Starfield.esm object within a configurable
capture radius. Produces multiple variation prefabs ready to use in
dungeon generation.

New files:
- Retrograde.Library/FurnitureHarvester/FurnitureHarvester.cs
    Core scanner/prefab builder. Iterates interior CellBlocks, collects
    nearby objects per anchor instance, normalises positions via inverse
    yaw rotation, creates interior Cell + PackIn per cluster.
- gen_harvester.cs
    Entry point. Resolves baseForm by EditorID partial-match
    (Furniture → Statics → Activators → all) or 0xFormID. Sanitises
    label for EditorIDs, then calls FurnitureHarvester.Harvest().
- gen_harvester.bat / scripts/gen_harvester.sh
    Build-and-run scripts mirroring gen_roompackin pattern.

Updated:
- Program.cs: registers "gen_harvester" case and adds help text.

Usage:
  gen_harvester <baseForm> [radius=150] [maxVariants=50] [outputMod]

https://claude.ai/code/session_01B8LSZLCVdpbsETXpzMgZcf